### PR TITLE
Linking to do list repo within the fluree docs.

### DIFF
--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
@@ -575,7 +575,7 @@ A POST request to `/fdb/sub` handles subscriptions. More documentation on this f
 
 A POST request with an empty object or a GET request to `/fdb/new-keys` returns a valid public key, private key, and auth-id. Learn more about [how identity is established in Fluree](/guides/identity/auth-records#generating-a-public-private-key-auth-id-triple). These requests do not need to be signed.
 
-### pw/generate
+### /pw/generate
 
 See the [Password Management Guide](/guides/identity/password-management) for more information.
 
@@ -603,7 +603,7 @@ Body: {
   }
 ```
 
-### pw/renew
+### /pw/renew
 
 See the [Password Management Guide](/guides/identity/password-management) for more information.
 
@@ -620,7 +620,7 @@ Headers: { Authorization: "Bearer TOKEN-HERE" }
 Body: { "expire": "TIME IN EPOCH MS" }
 ```
 
-### pw/login
+### /pw/login
 
 See the [Password Management Guide](/guides/identity/password-management) for more information.
 

--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
@@ -575,7 +575,7 @@ A POST request to `/fdb/sub` handles subscriptions. More documentation on this f
 
 A POST request with an empty object or a GET request to `/fdb/new-keys` returns a valid public key, private key, and auth-id. Learn more about [how identity is established in Fluree](/guides/identity/auth-records#generating-a-public-private-key-auth-id-triple). These requests do not need to be signed.
 
-### /generate
+### pw/generate
 
 See the [Password Management Guide](/guides/identity/password-management) for more information.
 
@@ -603,7 +603,7 @@ Body: {
   }
 ```
 
-### /renew
+### pw/renew
 
 See the [Password Management Guide](/guides/identity/password-management) for more information.
 
@@ -620,7 +620,7 @@ Headers: { Authorization: "Bearer TOKEN-HERE" }
 Body: { "expire": "TIME IN EPOCH MS" }
 ```
 
-### /login
+### pw/login
 
 See the [Password Management Guide](/guides/identity/password-management) for more information.
 

--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-overview.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-overview.md
@@ -42,9 +42,9 @@ You need password authentication enabled to use these endpoints. See [config opt
 
 Action | Endpoint | Explanation
 -- | -- | --
-[Generate](/api/downloaded-endpoints/downloaded-examples#-generate) | `/fdb/[NETWORK-NAME]/[DBID]/pw/generate` | Returns a valid token for a given user or role. Sets a valid password for that user or role.
-[Renew](/api/downloaded-endpoints/downloaded-examples#-renew) | `/fdb/[NETWORK-NAME]/[DBID]/pw/renew` | Given a token in the header and a new expiration time, returns a new token for a given user or role.
-[Login](/api/downloaded-endpoints/downloaded-examples#-login) | `/fdb/[NETWORK-NAME]/[DBID]/pw/login` | Given a password and user or auth id, returns a valid token.
+[Generate](/api/downloaded-endpoints/downloaded-examples#generate) | `/fdb/[NETWORK-NAME]/[DBID]/pw/generate` | Returns a valid token for a given user or role. Sets a valid password for that user or role.
+[Renew](/api/downloaded-endpoints/downloaded-examples#renew) | `/fdb/[NETWORK-NAME]/[DBID]/pw/renew` | Given a token in the header and a new expiration time, returns a new token for a given user or role.
+[Login](/api/downloaded-endpoints/downloaded-examples#login) | `/fdb/[NETWORK-NAME]/[DBID]/pw/login` | Given a password and user or auth id, returns a valid token.
 
 ### Other endpoints
 

--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-overview.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-overview.md
@@ -38,7 +38,7 @@ Test Transact With | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/test-transact-with` |
 
 ### Password Authentication Endpoints
 
-You need password authentication enabled to use these endpoints. See [config options](/docs/getting-started/installation#password-and-jwt-token-settings) for all password authentication options. See the [Password Management Guide](/guides/identity/password-management) for more information.
+You need password authentication enabled to use these endpoints. See [config options](/docs/getting-started/installation#password-and-jwt-token-settings) for all password authentication options. See the [Password Management Guide](/guides/identity/password-management) for more information. For an implementation example refer to the [Comics Store](https://github.com/fluree/developer-hub) repo located in the Fluree Developer Hub.
 
 Action | Endpoint | Explanation
 -- | -- | --

--- a/src/content/1.0.0/docs/start/basic_schema.md
+++ b/src/content/1.0.0/docs/start/basic_schema.md
@@ -1,4 +1,4 @@
-## Start Here
+## Fluree Basics
 
 Once you've successfully downloaded or logged into Fluree, we recommend that you start with this section using 'FlureeQL' as your language setting (in the top left). 
 

--- a/src/content/1.0.0/docs/start/basic_schema.md
+++ b/src/content/1.0.0/docs/start/basic_schema.md
@@ -6,7 +6,9 @@ This section shows you how to create a simple schema and populate your ledger wi
 
 If you are using the user interface, you can issue all of the code on this page directly on the 'FlureeQL' page of your user interface. Make sure that you select 'Transact'.
 
-If you are using the API, you can issue all these transactions to endpoints ending with `/transact`. 
+If you are using the API, you can issue all these transactions to endpoints ending with `/transact`.
+
+To view an example application that uses Fluree for data management, visit the [to-do list generator](https://github.com/fluree/to-do-lists-generator) repository.
 
 ### New Ledger
 

--- a/src/content/1.0.0/docs/start/intro.md
+++ b/src/content/1.0.0/docs/start/intro.md
@@ -27,7 +27,7 @@ There are other resources in this documentation website, such as:
 - [Lessons](/lesson): lessons that guide you through key concepts in Fluree and let you try queries and transaction directly from this site. While the lessons are a good introduction, they are not comprehensive.
 - [Videos](/video): screen captures of how-to-use Fluree combined with relevant narration (some video transcripts are available, and others can be provided by request). The videos are not comprehensive, but are a good reference for particular topics. 
 
-Alternatively, follow this [to-do list generator](https://github.com/fluree/to-do-lists-generator) repo for an introductionary look at integrating Fluree in a React application.
+Alternatively, follow this [to-do list generator](https://github.com/fluree/to-do-lists-generator) repo for an introductionary example of integrating Fluree in a React application.
 
 ### Where Can I Get Help?
 If you can't find the answers you are looking for in our documentation, please let us know! We are always looking to improve the quality of support we provide.

--- a/src/content/1.0.0/docs/start/intro.md
+++ b/src/content/1.0.0/docs/start/intro.md
@@ -27,7 +27,7 @@ There are other resources in this documentation website, such as:
 - [Lessons](/lesson): lessons that guide you through key concepts in Fluree and let you try queries and transaction directly from this site. While the lessons are a good introduction, they are not comprehensive.
 - [Videos](/video): screen captures of how-to-use Fluree combined with relevant narration (some video transcripts are available, and others can be provided by request). The videos are not comprehensive, but are a good reference for particular topics. 
 
-Alternatively, follow this [to-do list generator](https://github.com/fluree/to-do-lists-generator) repo for an introductionary example of integrating Fluree in a React application.
+Alternatively, follow this [to-do list generator](https://github.com/fluree/to-do-lists-generator) repo for an introduction to integrating Fluree in a React application.
 
 ### Where Can I Get Help?
 If you can't find the answers you are looking for in our documentation, please let us know! We are always looking to improve the quality of support we provide.

--- a/src/content/1.0.0/docs/start/intro.md
+++ b/src/content/1.0.0/docs/start/intro.md
@@ -27,6 +27,8 @@ There are other resources in this documentation website, such as:
 - [Lessons](/lesson): lessons that guide you through key concepts in Fluree and let you try queries and transaction directly from this site. While the lessons are a good introduction, they are not comprehensive.
 - [Videos](/video): screen captures of how-to-use Fluree combined with relevant narration (some video transcripts are available, and others can be provided by request). The videos are not comprehensive, but are a good reference for particular topics. 
 
+Alternatively, follow this [to-do list generator](https://github.com/fluree/to-do-lists-generator) repo for an introductionary look at integrating Fluree in a React application.
+
 ### Where Can I Get Help?
 If you can't find the answers you are looking for in our documentation, please let us know! We are always looking to improve the quality of support we provide.
 

--- a/src/content/1.0.0/guides/identity/password_management.md
+++ b/src/content/1.0.0/guides/identity/password_management.md
@@ -27,4 +27,4 @@ When you generate a password, a new auth record is created in your given ledger.
 
 The salt, the normalized password, and the `fdb-pw-auth-secret` are all used to regenerate the private key, and sign a request on behalf of the user. 
 
-When you `generate`, `renew`, or `login`, the response is a token, which then can be used in any subsequent request as authorization by placing the token the Authorization header: `Headers: { Authorization: "Bearer TOKEN-HERE" }`. 
+When you `generate`, `renew`, or `login`, the response is a token, which then can be used in any subsequent request as authorization by placing the token the Authorization header: `Headers: { Authorization: "Bearer TOKEN-HERE" }`. For an implemention example refer to the [Comic Store](https://github.com/fluree/developer-hub) repo located in the Fluree Developer Hub.


### PR DESCRIPTION
I moved the [to-do list repo](https://github.com/fluree/to-do-lists-generator) to the fluree org, now it's ready to be linked within our docs. Although there will probably be restructuring of the docs in the near future, there are two places that could already accommodate a link to my application. 

During the meeting with Amanda and Trey we agreed that [Start Here](https://docs.flur.ee/docs/1.0.0/getting-started/start-here) is a good place to add it, but I also think that fitting it in the *Other Resources* section found on the [intro](https://docs.flur.ee/docs/1.0.0/getting-started/intro) page would be helpful since a user could go to either one to begin. 

If there are other places that come to mind, or other ways I should link my repo please leave comments