### PR TITLE
FC-1142 correct query example

### DIFF
--- a/src/content/0.15.0/docs/query/basic-query.md
+++ b/src/content/0.15.0/docs/query/basic-query.md
@@ -52,7 +52,7 @@ Predicates do not have to be namespaced. The collection can often (but not alway
 
 ```all
 {
-    "select": ["chat/message", "instant", "*", ],
+    "select": ["chat/message", "instant", "*"],
     "from": "chat"
 }
 ```

--- a/src/content/0.17.0/docs/query/basic-query.md
+++ b/src/content/0.17.0/docs/query/basic-query.md
@@ -52,7 +52,7 @@ Predicates do not have to be namespaced. The collection can often (but not alway
 
 ```all
 {
-    "select": ["chat/message", "instant", "*", ],
+    "select": ["chat/message", "instant", "*"],
     "from": "chat"
 }
 ```

--- a/src/content/1.0.0/docs/query/basic-query.md
+++ b/src/content/1.0.0/docs/query/basic-query.md
@@ -52,7 +52,7 @@ Predicates do not have to be namespaced. The collection can often (but not alway
 
 ```all
 {
-    "select": ["chat/message", "instant", "*", ],
+    "select": ["chat/message", "instant", "*"],
     "from": "chat"
 }
 ```


### PR DESCRIPTION
removed extra comma from the example in query overview for v015, v0.17 & v1.0