### PR TITLE
Add prismjs additional languages

### DIFF
--- a/src/content/0.10.0/lessons/im-query/7.md
+++ b/src/content/0.10.0/lessons/im-query/7.md
@@ -2,7 +2,7 @@
 
 Take a look at the below query.
 
-```
+```json
 {
     "select": "?nums",
     "where": [ 

--- a/website/docs/concepts/analytical-queries/full-text-search.md
+++ b/website/docs/concepts/analytical-queries/full-text-search.md
@@ -5,7 +5,7 @@ a given collection. In order to do this, you first need to enable full text sear
 on any predicates you want to be able to search. For example, we're going to enable
 full text search on `person/fullName`, `person/handle`, and `chat/message`.
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "person/fullName"],
     "fullText": true
@@ -20,7 +20,7 @@ full text search on `person/fullName`, `person/handle`, and `chat/message`.
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -56,14 +56,14 @@ Transactions not supported in SPARQL.
 A predicate can be removed from the full-text search index (and thus from full-text
 search capability) at any time by simply setting `fullText` to false:
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "person/fullName"],
     "fullText": false
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -92,7 +92,7 @@ Now, we can issue a full text query against any predicate or collection by using
 a special predicate, `fullText:PREDICATE` or `fullText:COLLECTION`, which acts
 as a service call. For example:
 
-```flureeql
+```json
 {
     "select": "?person",
     "where": [
@@ -101,7 +101,7 @@ as a service call. For example:
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -130,7 +130,7 @@ includes the word `doe` (not case-sensitive). We can also issue the same query
 searching any full-text-searchable predicates in the `person` collection. In
 this case, we would be searching the predicates: `person/fullName` and `person/handle`.
 
-```flureeql
+```json
 {
     "select": "?person",
     "where": [
@@ -139,7 +139,7 @@ this case, we would be searching the predicates: `person/fullName` and `person/h
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -166,7 +166,7 @@ WHERE {
 We can combine a full-text search service call clause with any other clause, for
 example:
 
-```flureeql
+```json
 {
     "select": ["?person", "?nums", "?age"
     "where": [
@@ -177,7 +177,7 @@ example:
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -208,14 +208,14 @@ WHERE {
 A predicate can be removed from the full-text search index (and thus from full-text
 search capability) at any time by simply setting `fullText` to false:
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "person/fullName"],
     "fullText": false
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/concepts/analytical-queries/inner-joins-in-fluree.md
+++ b/website/docs/concepts/analytical-queries/inner-joins-in-fluree.md
@@ -5,7 +5,7 @@ tuple acts as a pattern in a where-array. First it pulls all the data that match
 that given pattern, and then it binds the appropriate variables. For example, we
 can issue the following query:
 
-```all
+```json
 {
     "select": ["?person", "?handle"],
     "where": [["?person", "person/handle", "?handle"]]
@@ -66,7 +66,7 @@ To recur across a relationship, simply add a `+` after a predicate. This will ma
 flakes any path length from the original. By default the recur depth is 100. You
 can also specify a certain path length by adding an integer after the `+`.
 
-```flureeql
+```json
 {
     "select": ["?followHandle"],
     "where": [
@@ -77,7 +77,7 @@ can also specify a certain path length by adding an integer after the `+`.
 }
 ```
 
-```curl
+```bash
  curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -107,7 +107,7 @@ WHERE {
 
 Below is an example specifying a maximum recursion depth.
 
-```flureeql
+```json
 {
     "select": ["?followHandle"],
     "where": [
@@ -119,7 +119,7 @@ Below is an example specifying a maximum recursion depth.
 }
 ```
 
-```curl
+```bash
  curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/concepts/architecture/flake.md
+++ b/website/docs/concepts/architecture/flake.md
@@ -214,7 +214,7 @@ Subject Identities for Jane Doe (written as JSON in this example):
 In most cases for Fluree, any Subject Identity can be used to refer to a subject.
 Therefore, the following three FlureeQL queries would return identical results:
 
-```all
+```json
 {"select": ["*"] from 45839457}
 {"select": ["*"] from ["email", "jane@doe.com"]}
 {"select": ["*"] from ["username", "janedoe"]}
@@ -348,14 +348,14 @@ metadata, might look like:
 As the `t` value is just another subject id, it can also be queried like any other
 data. The following would return all of the metadata about transaction -42:
 
-```all
+```json
 {"select": ["*"] from -42}
 ```
 
 If one wanted to list the hash and email of the person that transacted data for every
 transaction, the following query would suffice:
 
-```all
+```json
 {"select": ["?t", "?hash", "?email"],
  "where": [["?t",    "hash",  "?hash"],
            ["?t",    "auth",  "?auth"],
@@ -411,7 +411,7 @@ value.
 To see `_block/instant` and all other block metadata for all blocks in a ledger,
 query:
 
-```all
+```json
 {"select": ["*"], "from": "_block"}
 ```
 
@@ -420,7 +420,7 @@ To issue a query to a database as of a previous moment in time, a block number,
 uses `t` under the covers - providing a value other than `t` will prompt Fluree to
 query its data to find the nearest `t`. Examples:
 
-```all
+```json
 // Using a block number, looks up _block/transactions to get to 't'
 {"select": ["*"], "from": "person", "block": 2}
 // Using a 't' value, no conversion needed to 't'

--- a/website/docs/concepts/architecture/indexes.md
+++ b/website/docs/concepts/architecture/indexes.md
@@ -150,7 +150,7 @@ Tell me everything about John Smith
 
 Query:
 
-```all
+```json
 // Fluree will lookup ["username", "jsmith"] and resolve it to s = 26
  {"select": ["*"], 
  "from": ["username", "jsmith"]}
@@ -181,7 +181,7 @@ Tell me who John Smith follows
 
 Query:
 
-```all
+```json
 {"select": ["?following"], 
  "where": [[26 "follows" "?following"]]}
 

--- a/website/docs/concepts/examples/cryptocurrency.md
+++ b/website/docs/concepts/examples/cryptocurrency.md
@@ -9,7 +9,7 @@ The first step is to create a `wallet` collection with the predicates `wallet/ba
 which tracks the amount of currency each user has, `wallet/user`, which references
 a database `_user`, and `wallet/Name`, which is a unique name for the subject.
 
-```flureeql
+```json
 [{
     "_id": "_collection",
     "name": "wallet"
@@ -33,7 +33,7 @@ a database `_user`, and `wallet/Name`, which is a unique name for the subject.
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -82,7 +82,7 @@ a schema you should add in your sample data or initial data.
 
 We'll be creating two users, and two wallets.
 
-```all
+```json
 [{
     "_id": "_user$cryptoMan",
     "username": "cryptoMan"
@@ -128,7 +128,7 @@ First, we use `str` to create a query-string, `(str \"{\\\"select\\\":
 [{\\\"wallet/user\\\": [{\\\"_user/auth\\\": [\\\"_id\\\"]}]}], \\\"from\\\": \"
 (?sid) \" }\")`. The resulting query will be:
 
-```all
+```json
 {
   "select": [{"wallet/user": [{"_user/auth": ["_id]}]}],
   "from": SUBJECT-ID
@@ -143,7 +143,7 @@ use `get-all` to retrieve the `_id` of the `_user/auth`.
 see if the set of `_id`s for the current `wallet/user`s contains the `_id` of the
 `_auth` currently making the update `(?auth_id)`.
 
-```all
+```json
 [{
     "_id": "_fn$ownWallet",
     "name": "ownWallet?",
@@ -165,7 +165,7 @@ see if the set of `_id`s for the current `wallet/user`s contains the `_id` of th
 Then, we'll use the built-in smart functions, `true` and `false` to make sure `wallet/balance`
 can be updated by anyone, and the `wallet/user` cannot be edited by anyone.
 
-```all
+```json
 [{
     "_id": "_rule$editAnyCryptoBalance",
     "id": "editAnyCryptoBalance",
@@ -192,7 +192,7 @@ Now, we have three rules that we need to connect to the auth records. First, we'
 create a new predicate, `_auth/descId` (short for descriptive id), which will help
 us easily identify auth records.
 
-```flureeql
+```json
 [{
   "_id": "_predicate",
   "name": "_auth/descId",
@@ -215,7 +215,7 @@ directly in the downloadable version of Fluree.
 In the below example, we use a valid auth id/private key pair. If using this example
 in production, you should generate your own public/private/auth id triple.
 
-```flureeql
+```json
 [{
     "_id": "_role$cryptoUser",
     "id": "cryptoUser",
@@ -256,7 +256,7 @@ you can go to the [Smart Function](/guides/1.0.0/smart-functions) section.
 Note, this transaction, and many of the subsequent transactions can be combined.
 We separate out these transactions here for demonstration purposes.
 
-```flureeql
+```json
 [{  "_id":  ["_predicate/name", "wallet/balance"],
     "spec": ["_fn$nonNegative?"],
     "specDoc": "Balance cannot be negative."
@@ -268,7 +268,7 @@ We separate out these transactions here for demonstration purposes.
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -311,7 +311,7 @@ your `wallet/balance` to 0. In order to prevent this, we can create a rule that
 only allows you to withdraw from your own `wallet/balance` or deposit in another
 user's `wallet/balance`.
 
-```flureeql
+```json
 [{
         "_id": "_fn$subtractOwnAddOthers?",
         "name": "subtractOwnAddOthers?",
@@ -327,7 +327,7 @@ user's `wallet/balance`.
     }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -388,10 +388,12 @@ went through successfully, you will need to query:
 ```all
 Private Key: 745f3040cbfba59ba158fc4ab295d95eb4596666c4c275380491ac658cf8b60c
 Auth id: TfDao2xAPN1ewfoZY6BJS16NfwZ2QYJ2cF2
+```
 
+```json
 {
   "select": ["*"],
-  "from": ["_tx/id", TRANSACTION ID HERE ]
+  "from": ["_tx/id", 'TRANSACTION ID HERE' ]
 }
 ```
 
@@ -405,7 +407,9 @@ auth record you are using cannot view subjects in the `_tx` collection).
 ```all
 Private Key: 745f3040cbfba59ba158fc4ab295d95eb4596666c4c275380491ac658cf8b60c
 Auth id: TfDao2xAPN1ewfoZY6BJS16NfwZ2QYJ2cF2
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoWoman"],
     "balance": 205
@@ -450,7 +454,9 @@ TRANSACTION ID HERE ] }` in order to see the error.
 ```all
 Private Key: 745f3040cbfba59ba158fc4ab295d95eb4596666c4c275380491ac658cf8b60c
 Auth id: TfDao2xAPN1ewfoZY6BJS16NfwZ2QYJ2cF2
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoMan"],
     "balance": 205
@@ -490,7 +496,9 @@ succeed.
 ```all
 Private Key: 65a55074e1de61e08845d4dc5b997260f5f8c20b39b8070e7799bf92a006ad19
 Auth id: Tf6mUADU4SDa3yFQCn6D896NSdnfgQfzTAP
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoWoman"],
     "balance": 195
@@ -530,7 +538,9 @@ her `wallet/balance`.
 ```all
 Private Key: 65a55074e1de61e08845d4dc5b997260f5f8c20b39b8070e7799bf92a006ad19
 Auth id: Tf6mUADU4SDa3yFQCn6D896NSdnfgQfzTAP
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoWoman"],
     "balance": "#(+ (?pO) 5)"
@@ -567,7 +577,9 @@ Removing money from cryptoMan's wallet will also fail.
 ```all
 Private Key: 65a55074e1de61e08845d4dc5b997260f5f8c20b39b8070e7799bf92a006ad19
 Auth id: Tf6mUADU4SDa3yFQCn6D896NSdnfgQfzTAP
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoMan"],
     "balance": "#(- (?pO) 5)"
@@ -622,7 +634,7 @@ and sums all the false flakes in a transaction for the given `_predicate`. We wa
 to make sure that the sum of all of the `wallet/balance`s being retracted equals
 the sum of those being added.
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "wallet/balance"],
     "txSpec": ["_fn$evenCryptoBalance"],
@@ -637,7 +649,7 @@ the sum of those being added.
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -698,7 +710,9 @@ to be equal".
 ```all
 Private Key: 65a55074e1de61e08845d4dc5b997260f5f8c20b39b8070e7799bf92a006ad19
 Auth id: Tf6mUADU4SDa3yFQCn6D896NSdnfgQfzTAP
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoMan"],
     "balance": "#(+ (?pO) 10)"
@@ -745,10 +759,12 @@ can initiate the transaction. We can sign it as cryptoMan, and it will go throug
 
 But if we sign it as cryptoWoman, it will return an error.
 
-```flureeql
+```all
 Private Key: 65a55074e1de61e08845d4dc5b997260f5f8c20b39b8070e7799bf92a006ad19
 Auth id: Tf6mUADU4SDa3yFQCn6D896NSdnfgQfzTAP
+```
 
+```json
 [{
     "_id": ["wallet/name", "cryptoMan"],
     "balance": "#(- (?pO) 10)"

--- a/website/docs/concepts/examples/iam.md
+++ b/website/docs/concepts/examples/iam.md
@@ -38,7 +38,7 @@ value fields).
 You can copy/paste the following schema transaction into the Fluree Admin dashboard,
 to create the `illusion` collection and user roles in the ledger.
 
-```flureeql
+```json
 [
   {
     "_id": "_collection",
@@ -90,7 +90,7 @@ to create the `illusion` collection and user roles in the ledger.
 
 ### Seed Data {#seed-data}
 
-```flureeql
+```json
 [
   {
     "_id": "illusion#1",
@@ -128,7 +128,7 @@ We'll be using the [Password Authentication API](/guides/identity/password-manag
 to create our users. Using your API testing software, send a POST request with the
 following body to `http://localhost:8090/fdb/[NETWORK-NAME]/[DBID]/pw/generate`.
 
-```flureeql
+```json
 {
   "user": "greenhorn",
   "password": "alakazam",
@@ -159,7 +159,7 @@ user to the `pw/login` endpoint will return a JWT to use for authentication as w
 The following object would be included in the POST request body to login the created
 user.
 
-```flureeql
+```json
 {
   "user": "greenhorn",
   "password": "alakazam",
@@ -172,7 +172,7 @@ user.
 Let's try to query some illusions. With a valid JWT set in the Authorization header,
 send the following query to your Fluree ledger's `query` endpoint.
 
-```flureeql
+```json
 {
   "select": ["*"],
   "from": "illusion"
@@ -188,7 +188,7 @@ to our roles, so that our users can access the appropriate data for their trust 
 Transact the following array in the admin dashboard to give our each role appropriate
 query permissions for the `illusion` collection:
 
-```flureeql
+```json
 [
   {
     "_id": "_rule#initiatePermission",
@@ -244,7 +244,7 @@ one? That's as easy as updating our existing `magicianPermission` rule to allow 
 In the admin dashboard, transact the following block to allow "magician" users the
 ability to update and add to the `illusion` collection.
 
-```flureeql
+```json
 [
   {
     "_id": ["_rule/id", "magicianPermission"],
@@ -259,7 +259,7 @@ tag to the `_rule/ops` predicate to allow query & transaction operations.
 Now, try transacting the following block as an "initiate", and then attempt the
 same transaction as a "magician" user.
 
-```flureeql
+```json
 [
   {
     "_id": "illusion#new",

--- a/website/docs/concepts/examples/voting.md
+++ b/website/docs/concepts/examples/voting.md
@@ -27,7 +27,7 @@ of the auth records that voted yes or no, respectively, on the proposed change.
 
 FlureeQL:
 
-```all
+```json
 [
  {
   "_id": "_collection",
@@ -72,7 +72,7 @@ value, for instance, `John Doe`.
 
 FlureeQL
 
-```all
+```json
 [{
   "_id": "_predicate",
   "name": "change/name",
@@ -128,7 +128,7 @@ types of objects as well.
 First, we'll create a new predicate, `_auth/descId` (short for descriptive id),
 which will help us easily identify auth records.
 
-```flureeql
+```json
 [{
   "_id": "_predicate",
   "name": "_auth/descId",
@@ -189,7 +189,7 @@ Account id: Tf31KGiwsqnw1TWTWPspxi3AoHTCA1wJNaE
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_user$losDelRio",
     "username": "losDelRio",
@@ -273,7 +273,7 @@ The rules only allow users to view, but not edit, auth records and users.
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_rule$editVotes",
     "fns": [["_fn/name", "true"]],
@@ -310,7 +310,7 @@ FlureeQL:
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_rule$editOwnUser",
     "fns": ["_fn$editOwnUser"],
@@ -333,7 +333,7 @@ role that we created previously:
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": ["_role/id", "voter"],
     "rules": [["_rule/id", "editChanges"], ["_rule/id", "editVotes"], ["_rule/id",
@@ -353,7 +353,7 @@ The rule, `(== (?o) (?auth_id))` checks whether the object being added to the vo
 
 FlureeQL:
 
-```all
+```json
 [
     {
         "_id": "_fn$ownAuth",
@@ -398,7 +398,7 @@ A request to `/command` will return a `_tx/id`. The `_tx/id` is the unique
 SHA2-256 of the 'cmd' submitted to the `/command` endpoint. In order to see if the
 transaction went through successfully, you will need to query:
 
-```all
+```json
 {
   "select": ["*"],
   "from": ["_tx/id", TRANSACTION ID HERE ]
@@ -419,7 +419,9 @@ FlureeQL:
 ```all
 Private Key: 4b288665f5e5f9b1078d3c54f916a86433557fbc16ffcb8de827104739c84ed4
 Auth id: TfHzKHsTdXVhbjskqesPTi6ZqwXHghFb1yK
+```
 
+```json
 [{
     "_id": "change",
     "name": "softCellNameChange",
@@ -448,7 +450,7 @@ We can see all the votes related to that subject with a single query.
 
 FlureeQL:
 
-```all
+```json
 {
     "select": {"?change": ["*", {"change/vote": ["*"]}]},
     "where": [["?change", "change/subject", "?subject"],
@@ -468,7 +470,7 @@ we need add that `change/predicate` is `["_predicate/name", "_user/username"]` a
 
 FlureeQL:
 
-```all
+```json
 {
     "select": {"?vote": ["*"]},
     "where": [["?change", "change/subject", "?subject"],
@@ -482,7 +484,7 @@ FlureeQL:
 
 Sample result in FlureeQL:
 
-```all
+```json
 [
   {
     "vote/name": "softCellNameVote",
@@ -516,7 +518,7 @@ information we need in order to compose our where clause.
 
 Without escaped quotation marks, our where clause will be:
 
-```all
+```json
 [
     ["?change", "change/subject", (?sid)],
     ["?change", "change/predicate", (?pid)],
@@ -527,7 +529,7 @@ Without escaped quotation marks, our where clause will be:
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_fn",
     "name": "voteWhere",
@@ -544,7 +546,7 @@ The second function we create issues a query using the `query` smart function. T
 
 The query in our smart function resolves to:
 
-```all
+```json
 {
     "select": {"?vote": ["*"]},
     "where": [["?change", "change/subject", (?sid)],
@@ -556,7 +558,7 @@ The query in our smart function resolves to:
 
 FlureeQL:
 
-```all
+```json
 [{
         "_id": "_fn",
         "name": "vote",
@@ -574,7 +576,7 @@ and `["vote/yesVotes" \"_id\"]`, respectively)`.
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_fn",
     "name": "noVotes",
@@ -598,7 +600,7 @@ a percentage, we use a `_fn/param`.
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_fn",
     "name": "minWinPercentage",
@@ -612,7 +614,7 @@ votes is above a given parameter, `n`.
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_fn",
     "name": "minVotes",
@@ -631,7 +633,7 @@ Additionally, the percentage needs to be in decimal form with a leading 0).
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": "_fn",
     "name": "2VotesMajority",
@@ -647,7 +649,7 @@ the `2VotesMajority` will run.
 
 FlureeQL:
 
-```all
+```json
 [{
     "_id": ["_predicate/name", "_user/username"],
     "spec": [["_fn/name", "2VotesMajority"]]
@@ -665,7 +667,9 @@ FlureeQL:
 ```all
 Private Key: 4b288665f5e5f9b1078d3c54f916a86433557fbc16ffcb8de827104739c84ed4
 Auth id: TfHzKHsTdXVhbjskqesPTi6ZqwXHghFb1yK
+```
 
+```json
 [{
     "_id": ["_user/username", "softCell"],
     "username": "hardCell"
@@ -674,7 +678,7 @@ Auth id: TfHzKHsTdXVhbjskqesPTi6ZqwXHghFb1yK
 
 Response:
 
-```all
+```json
 {
   "_tx/id": "6b9f5fe96564289e267bc5d1611c61021053e8de4e95f0777247239a8b9ca1cd",
   "_tx/auth": {
@@ -695,7 +699,9 @@ FlureeQL:
 ```all
 Private Key: 46e37823bfe73ac2b5e440238cb2b65a1cb4115721f23202e543c454faab8449
 Auth id: TfFoQ4yB3vFn3th7Vce36Cb45fDau255GdH
+```
 
+```json
 [{
     "_id": ["vote/name", "softCellNameVote"],
     "yesVotes": [["_auth/id", "TfFoQ4yB3vFn3th7Vce36Cb45fDau255GdH"]]
@@ -709,7 +715,9 @@ FlureeQL:
 ```all
 Private Key: afa6b042a342845c3bf4ea5fd2690d8548d5169fd18d18081ac8ac9093c2e43c
 Auth id: TfBvBxdxcXNrDQY8aNcYmoUuA2TC1CTiWAK
+```
 
+```json
 [{
     "_id": ["vote/name", "softCellNameVote"],
     "yesVotes": [["_auth/id", "TfBvBxdxcXNrDQY8aNcYmoUuA2TC1CTiWAK"]]
@@ -722,7 +730,9 @@ transaction as Soft Cell's auth record.
 ```all
 Private Key: 4b288665f5e5f9b1078d3c54f916a86433557fbc16ffcb8de827104739c84ed4
 Auth id: TfHzKHsTdXVhbjskqesPTi6ZqwXHghFb1yK
+```
 
+```json
 [{
     "_id": ["_user/username", "softCell"],
     "username": "hardCell"

--- a/website/docs/concepts/identity/auth_records.md
+++ b/website/docs/concepts/identity/auth_records.md
@@ -29,7 +29,7 @@ There are many ways to generate valid public-private key/auth id triple:
 Once you have a valid auth record (and you have saved the private key
 somewhere!), you must add the auth record to a ledger.
 
-```all
+```json
 [{
     "_id": "_auth",
     "id": "kh90sdlsdmyFakeAuthId",
@@ -159,7 +159,7 @@ Private Key:            a12f89d64f966d431ea4fff850baf01f501438ccea53b6f6bb041e9e
 
 To test this out, we can add two auth records:
 
-```all
+```json
 [{
     "_id": "_auth$IT",
     "id": "Tf5q9TVMoJ2MSATxN5XhAizBMSBEUGuy8aU",
@@ -192,7 +192,9 @@ The IT Team (the authority in this case) has to verify whether or not the person
 ```all
 Auth Record:    Alba
 Private Key:    a12f89d64f966d431ea4fff850baf01f501438ccea53b6f6bb041e9eed559a76
+```
 
+```json
 [{
     "_id": "person", 
     "handle": "aJohnson", 

--- a/website/docs/concepts/identity/password_management.md
+++ b/website/docs/concepts/identity/password_management.md
@@ -23,7 +23,7 @@ There are three API endpoints associated with passwords - [generate, renew, and 
 When you generate a password, a new auth record is created in your given ledger.
  For example:
 
-```all
+```json
 [{
     "_id": 105553116267496,
     "_auth/id": "Tf9Sn7cR3dRpdVJYXiRYY2TeNhJLpb2eLDS",

--- a/website/docs/concepts/identity/signatures.md
+++ b/website/docs/concepts/identity/signatures.md
@@ -87,7 +87,7 @@ query.
 
 ### Example {#example}
 
-```all
+```http
  {
       method: 'POST',
       headers: {

--- a/website/docs/concepts/infrastructure/in_memory.md
+++ b/website/docs/concepts/infrastructure/in_memory.md
@@ -12,7 +12,7 @@ Full-text indexing and full-text search are not available when running Fluree in
 
 To try this out, we can clone down the tx-group-ex-dirs repo.
 
-```all
+```bash
 git clone https://github.com/fluree/tx-group-ex-dirs.git
 ```
 

--- a/website/docs/concepts/infrastructure/transactor_group.md
+++ b/website/docs/concepts/infrastructure/transactor_group.md
@@ -26,7 +26,7 @@ fdb-group-servers  | myserver1@localhost:9790,myserver2@localhost:9791,myserver3
 
 To start this up very quickly, you can clone down the tx-group-ex-dirs repo.
 
-```all
+```bash
 git clone https://github.com/fluree/tx-group-ex-dirs.git
 ```
 
@@ -44,7 +44,7 @@ and `fluree-3/`, respectively.  In each of those terminal windows, you can issue
 When you see a log like the below, you can `cmd + click` on the URL to open the
 admin UI for each server.
 
-```all
+```bash
 INFO  fluree.db.peer.http-api - Starting web server on port: 8090 with an open API.
 INFO  fluree.db.peer.http-api -
 INFO  fluree.db.peer.http-api - http://localhost:8090
@@ -82,7 +82,7 @@ fdb-group-servers  | myserver1@localhost:9790,myserver2@localhost:9791,myserver3
 
 To start this up very quickly, you can clone down the tx-group-ex-dirs repo.
 
-```all
+```bash
 git clone https://github.com/fluree/tx-group-ex-dirs.git
 ```
 
@@ -100,7 +100,7 @@ respectively.
 When you see a log like the below, you can `cmd + click` on the URL to open the
 admin UI for each server.
 
-```all
+```bash
 INFO  fluree.db.peer.http-api - Starting web server on port: 8090 with an open API.
 INFO  fluree.db.peer.http-api -
 INFO  fluree.db.peer.http-api - http://localhost:8090
@@ -128,7 +128,7 @@ fdb-group-servers  | myserver1@localhost:9790,myserver2@localhost:9791,myserver3
 
 To start this up, we can clone down the tx-group-ex-dirs repo.
 
-```all
+```bash
 git clone https://github.com/fluree/tx-group-ex-dirs.git
 ```
 
@@ -170,7 +170,7 @@ First we need to start `myserver4`. To do this, you can open a terminal and issu
 
 You'll see some logs like:
 
-```all
+```bash
 INFO  fluree.db.peer.http-api - Starting web server on port: 8083 with an open API.
 INFO  fluree.db.peer.http-api -
 INFO  fluree.db.peer.http-api - http://localhost:8083
@@ -183,7 +183,7 @@ INFO  f.d.ledger.consensus.tcp - TCP read channel closed for server: myserver4. 
 2. Issue a request to any active server (in this case, to server `myserver1`) to
   add `myserver4`.
 
-```all
+```bash
   curl \
    -H "Content-Type: application/json" \
    -d '{"server": "myserver4"}' \
@@ -192,13 +192,13 @@ INFO  f.d.ledger.consensus.tcp - TCP read channel closed for server: myserver4. 
 
 If adding the server is successful, you should see a log like:
 
-```all
+```bash
 Committing myserver4 add to the network configuration. Change command id: eeeda1b7-c939-4eea-885c-96b0e87f394b
 ```
 
 If it was not successfully added, you'll see a message like:
 
-```all
+```bash
 WARN  fluree.raft.leader - Server myserver4 did not sync in the allotted number
 of rounds. Please delete this server's files, and attempt to add again. Depending
 on your network's connectivity, you may want to increase :fdb-group-catch-up-rounds.
@@ -211,7 +211,7 @@ This is a beta feature, so if you encounter any issues, please email `support@fl
 If you have a server running, you can dynamically remove a server by issue a request
 like the below to any server in the network (including the server to be removed).
 
-```all
+```bash
   curl \
    -H "Content-Type: application/json" \
    -d '{"server": "myserver1"}' \

--- a/website/docs/concepts/smart-functions/collection-spec.md
+++ b/website/docs/concepts/smart-functions/collection-spec.md
@@ -19,7 +19,7 @@ If we want to make `person/fullName` required, we need to first create a smart f
 
 It might be tempting to think that, because this smart function pertains to one specific predicate, then we should use a predicate spec. However, we could be creating new people with the following transaction:
 
-```all
+```json
 [{
   "_id": "person",
   "handle": "gWash"
@@ -36,7 +36,7 @@ Note, in our smart function, we first use our `?sid` to find the `person/fullNam
 
 In the below transaction, we first attach the `_fn$fullNameReq` to the `person` collection, and write a `specDoc`. The `specDoc` is the custom error message that will display when this smart function returns false. In the second part of the transaction, we create the relevant smart function, `fullNameReq`.
 
-```flureeql
+```json
 [{
   "_id": ["_collection/name", "person"],
   "spec": ["_fn$fullNameReq"],
@@ -49,7 +49,7 @@ In the below transaction, we first attach the `_fn$fullNameReq` to the `person` 
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -82,14 +82,14 @@ Transactions not supported in SPARQL
 
 After we add this `_collection/spec`, the following transaction should fail:
 
-```flureeql
+```json
 [{
     "_id": "person",
     "handle": "noFullName"
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/concepts/smart-functions/fns-in-txs.md
+++ b/website/docs/concepts/smart-functions/fns-in-txs.md
@@ -6,14 +6,14 @@ To use smart functions directly in transactions, we need to put our code inside 
 
 For example, to add ", Sr." to the end of a person's full name, we can use two built-in smart functions, `str` and `?pO`. `str` concatenates strings, and `?pO` retrieves the previous object. In this case, we expect the final object of `person/fullName` to be `Jane Doe, Sr.`.
 
-```flureeql
+```json
 [{
   "_id": ["person/handle", "jdoe"],
   "fullName": "#(str (?pO) \", Sr.\")"
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -44,7 +44,7 @@ An atomic compare and set function can protect the integrity of a transaction wh
 
 Say you wanted to add a 'Dr.' in front of every medical doctor's name. You issue a query for all people whose title is doctor, and do some logic to filter all names that don't already start with 'Dr.'. It happens that Jane Doe and John Smith are missing the Dr. prefix. A `cas` use might look like:
 
-```flureeql
+```json
 [{"_id": 1234 
   "fullName": "#(cas \"Jane Doe\" \"Dr. Jane Doe\")"},
   "_id": 5678 
@@ -58,7 +58,7 @@ If between your query and this transaction getting executed another transaction 
 
 In another example, say you had multiple microservices that required a synthetic lock on a value. `cas` can test that the lock still exists before updating a different value. In this example, each lock can have a unique `lock/id`, and if a lock is active then `isLocked` will be `true`.
 
-```flureeql
+```json
 [{"_id": ["lock/id", 12345] 
   "isLocked": "#(cas true false)"},
  {"_id": 5678 

--- a/website/docs/concepts/smart-functions/intro.md
+++ b/website/docs/concepts/smart-functions/intro.md
@@ -8,7 +8,7 @@ We also have a <a href="https://github.com/fluree/smart-function-library" target
 
 For some additional help testing and debugging your smart function implementations, try updating your `logback.xml` configuration file (located in your Fluree directory) so that logging for `fluree.db` is set to `DEBUG`, e.g.
 
-```all
+```xml
 <configuration scan="true">
     ...
     <logger name="fluree.db" level="DEBUG"/>

--- a/website/docs/concepts/smart-functions/predicate-spec.md
+++ b/website/docs/concepts/smart-functions/predicate-spec.md
@@ -22,7 +22,7 @@ If we want to make sure that `person/favNums` is always non-negative, we need to
 
 Create a Non-Negative Function:
 
-```flureeql
+```json
 [{
     "_id": "_fn",
     "name": "nonNegative?",
@@ -31,7 +31,7 @@ Create a Non-Negative Function:
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -60,14 +60,14 @@ Transactions not supported in SPARQL
 
 Add function to the `_predicate/spec` for `person/favNums`:
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "person/favNums"],
     "spec": [["_fn/name", "nonNegative?"]]
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -94,7 +94,7 @@ Transactions not supported in SPARQL
 
 If you try to issue the following transaction, it will fail, because -4 is negative.
 
-```flureeql
+```json
 [{
     "_id": "person",
     "handle": "aJay",
@@ -102,7 +102,7 @@ If you try to issue the following transaction, it will fail, because -4 is negat
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/concepts/smart-functions/rule-example.md
+++ b/website/docs/concepts/smart-functions/rule-example.md
@@ -14,7 +14,7 @@ In this section, we will create two roles, level1User and level2User, and connec
 
 First, we need to create a new predicate, which connects a `person` to a `_auth`.
 
-```flureeql
+```json
 [{
   "_id":    "_predicate",
   "name":   "person/auth",
@@ -24,7 +24,7 @@ First, we need to create a new predicate, which connects a `person` to a `_auth`
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -d '[{
@@ -67,7 +67,7 @@ The full function is: `(contains? (get-all (?s \"[{chat/person [{person/auth [_i
 2. Then, we retrieve all (just one in this case) of the _auth_ids by again crawling the results from step 1. `(get-all [\"chat/person\" \"person/auth\" \"_id\"])`.
 3. Finally, we ask, does the set (of one) _id contain the (?auth_id) who is currently making this update. `(contains? (get-all (?s \"[{chat/person [{person/auth [_id] }] }]\") [\"chat/person\" \"person/auth\" \"_id\"]) (?auth_id))`.
 
-```flureeql
+```json
 [
   {
     "_id": "_role",
@@ -110,7 +110,7 @@ The full function is: `(contains? (get-all (?s \"[{chat/person [{person/auth [_i
 ]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -181,7 +181,7 @@ We've already created the rules, `viewAllChats` and `editOwnChats`, so we just n
 
 We will need to create two new rules, `viewAllPeople` and `viewAllComments`.
 
-```flureeql
+```json
 [
   {
     "_id": "_role",
@@ -210,7 +210,7 @@ We will need to create two new rules, `viewAllPeople` and `viewAllComments`.
 ]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -d '[
@@ -282,7 +282,7 @@ Account id: TfFzb1tZDkGMBqWr8xMmRVvYmNYFKH9aNpi
 
 Now, we'll create the auth records and connect them to both the relevant roles and people. `jdoe` will be a level 1 user, and `zsmith` will be level 2.
 
-```flureeql
+```json
 [
   {
     "_id": ["person/handle", "jdoe"],
@@ -307,7 +307,7 @@ Now, we'll create the auth records and connect them to both the relevant roles a
 ]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -d '[
@@ -361,7 +361,7 @@ When we sign queries as `jdoe`, with a private key of `1787cab58d5b146a049f220c9
 
 Query All Chats
 
-```all
+```json
 {
   "select": ["*", {"chat/comments": ["*"]}],
   "from": "chat"
@@ -370,7 +370,7 @@ Query All Chats
 
 Results:
 
-```all
+```json
 [
   {
     "chat/message": "This is a sample chat from Jane!",
@@ -392,7 +392,7 @@ When we query all people:
 
 Query:
 
-```all
+```json
 {
   "select": ["*"],
   "from": "person"
@@ -401,7 +401,7 @@ Query:
 
 Results:
 
-```all
+```json
 [
   {
     "person/handle": "zsmith",
@@ -420,7 +420,7 @@ Results:
 
 `jdoe` can edit an old chat.
 
-```all
+```json
 [{
   "_id": 369435906932737,
   "message": "I *can* change this"
@@ -429,7 +429,7 @@ Results:
 
 `jdoe` can also create a new chat, as herself.
 
-```all
+```json
 [{
   "_id": "chat",
   "message": "Hey there!",
@@ -439,7 +439,7 @@ Results:
 
 `jdoe` cannot create a new chat as `zsmith`, or anyone else.
 
-```all
+```json
 [{
   "_id": "chat",
   "message": "What's up?",
@@ -455,7 +455,7 @@ When we sign queries as `zsmith`, with a private key of `c0588115314065f7949f87f
 
 Query All Chats
 
-```all
+```json
 {
   "select": ["*"],
   "from": "chat"
@@ -464,7 +464,7 @@ Query All Chats
 
 Results:
 
-```all
+```json
   {
     "chat/message": "Hey there!",
     "chat/person": {
@@ -498,7 +498,7 @@ When we query all people:
 
 Query:
 
-```all
+```json
 {
   "select": ["*"],
   "from": "person"
@@ -507,7 +507,7 @@ Query:
 
 Results:
 
-```all
+```json
 [
   {
     "person/auth": {
@@ -570,7 +570,7 @@ Results:
 
 `zsmith` can create a new chat, as himself.
 
-```all
+```json
 [{
   "_id": "chat",
   "message": "Hi, I'm Zach!",
@@ -580,7 +580,7 @@ Results:
 
 `zsmith` cannot create a new chat as `jdoe`, or anyone else.
 
-```all
+```json
 [{
   "_id": "chat",
   "message": "I'm trying to impersonate jdoe",

--- a/website/docs/concepts/what-is-fluree.md
+++ b/website/docs/concepts/what-is-fluree.md
@@ -70,7 +70,7 @@ We can think of the ledger at any given point in time as the combination of all 
 
 The below image shows you a simplified representation of five blocks worth of flakes. In the first two blocks, we create our simple schema (a user with a `user/handle` and a `user/chat`). In block 3, we add a new user named 'bob' and a chat message for Bob. In block 4, we create a new user with the handle 'jane', and finally in block 5, we attribute a chat to 'jane'.
 
-<p class="text-center">
+<p className="text-center">
     <img width="600px" height="220px" src="https://s3.amazonaws.com/fluree-docs/flakeLogBlocks1-5.png" alt="A table with the columns: 'subject', 'predicate', 'object', 'block', and 'add.' There are seven rows in this table, and each contains sample data, which is explained in the accompanying paragraph"/>
 </p>
 

--- a/website/docs/concepts/what-is-fluree.md
+++ b/website/docs/concepts/what-is-fluree.md
@@ -33,7 +33,7 @@ These atomic updates are very specially formatted logs. Each update is a called 
 
 Below is an example of ledger block. We will go into detail about the contents of the transaction response in the [Block Metadata](#block-metadata) section. However, below you can see that, among other things, every block contains a hash, a timestamp, and the size of the block data (block-bytes). This block also contains an array of nine flakes. These flakes contain all the data that is added, updated, or deleted in block 5, as compared to block 4.
 
-```all
+```json
 {
   "tempids": {
     "chat$1": 4299262263297

--- a/website/docs/guides/advanced/cryptography/5.md
+++ b/website/docs/guides/advanced/cryptography/5.md
@@ -24,25 +24,25 @@ There are two signatures in block metadata. Neither are included in the block ha
     When a user submits a transaction, they sign their transaction with their private key.
     The above flake that contains `_tx/sig` from Lesson 3.
 
-        ```json
-        [
-        -25,
-        107,
-        "1b3045022100e1086f4399b46360f35955a057f254c1aec0c4868696de8c5c4d9b04ff8523ae0220328350a24075c3fa2ea1aaa32be88093378b9b7f7f5825040cbe58d303cf7b3a",
-        -25,
-        true,
-        null
-        ]
-        ```
+    ```json
+    [
+     -25,
+     107,
+     "1b3045022100e1086f4399b46360f35955a057f254c1aec0c4868696de8c5c4d9b04ff8523ae0220328350a24075c3fa2ea1aaa32be88093378b9b7f7f5825040cbe58d303cf7b3a",
+     -25,
+     true,
+     null
+    ]
+    ```
 
-    The above flake that contains `_tx/sig` from Lesson 3.
+The above flake that contains `_tx/sig` from Lesson 3.
 
-1. `_block/sigs`
+2. `_block/sigs`
 
     Multiple transactors can sign a block. Each transactor uses their private key to sign a block. This, in effect, is their assertion that the block is valid. All
 
-        ```json
+       ```json
         [ -26, 7, "1c304402202e93e0e42faa01e4d8c6404ce656f3e562fbc095644cd0a810b46c0112e0c8280220494083304a0c9164ca2b1ffcdb8cf9a07ad233f6d9090df9b55906483046dd2a", -26, true, null ]
-        ```
+       ```
 
-    The above flake that contains `_block/sigs` from Lesson 3.
+The above flake that contains `_block/sigs` from Lesson 3.

--- a/website/docs/guides/advanced/smart-functions/3.md
+++ b/website/docs/guides/advanced/smart-functions/3.md
@@ -19,7 +19,7 @@ Linked is the full list of <a href="/docs/smart-functions#universal-functions" t
 
 Function code examples:
 
-```clj
+```clojure
 (+ 12 5)                                ;; 17
 (inc 10)                                ;; 11
 (== 1 1)                                ;; true

--- a/website/docs/guides/advanced/smart-functions/4.md
+++ b/website/docs/guides/advanced/smart-functions/4.md
@@ -36,7 +36,7 @@ For convenience, we've linked the full list of <a href="/docs/smart-functions#un
 
 Function code examples:
 
-```clj
+```clojure
 (+ 12 5)                                   ;; 17
 (inc 10)                                   ;; 11
 (== 1 1)                                   ;; true

--- a/website/docs/guides/advanced/smart-functions/5.md
+++ b/website/docs/guides/advanced/smart-functions/5.md
@@ -6,7 +6,7 @@ Linked is the full list of <a href="/docs/smart-functions#context-dependent-func
 
 Function code examples:
 
-```clj
+```clojure
 (< 1000 (?o))
 (== (?auth_id) (?sid))
 (+ (objT) 100)

--- a/website/docs/guides/querying/query-advanced/7.md
+++ b/website/docs/guides/querying/query-advanced/7.md
@@ -2,7 +2,7 @@
 
 Take a look at the below query.
 
-```jsonc
+```json
 {
   "select": "?nums",
   "where": [

--- a/website/docs/overview/fluree_basics.md
+++ b/website/docs/overview/fluree_basics.md
@@ -50,7 +50,7 @@ and `movie`. You can issue this transaction in your user interface. The syntax i
 explained in the [Transact](/docs/transact/basics) section. For now, we recommend
 you adding this basic schema and walking through the documentation section-by-section.
 
-```flureeql
+```json
 [{
  "_id": "_collection",
  "name": "person"
@@ -73,7 +73,7 @@ you adding this basic schema and walking through the documentation section-by-se
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -140,7 +140,7 @@ The below transaction creates the following predicates:
 - `artist/name`
 - `movie/title`
 
-```flureeql
+```json
 [{
   "_id":    "_predicate",
   "name":   "person/handle",

--- a/website/docs/overview/fluree_basics.md
+++ b/website/docs/overview/fluree_basics.md
@@ -257,7 +257,7 @@ The below transaction creates the following predicates:
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -434,7 +434,7 @@ You can issue the below transaction to add some sample data into your ledger. Th
 below transaction adds four users, three chats, four comments, three artists, and
 three movies.
 
-```flureeql
+```json
 [{
   "_id":      "person$jdoe",
   "handle":   "jdoe",
@@ -541,7 +541,7 @@ three movies.
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/overview/query/advanced-query.md
+++ b/website/docs/overview/query/advanced-query.md
@@ -2,7 +2,7 @@
 
 In this section, we show you different advanced query capabilities.
 
-Different query types in this section should be issued to different API endpoints. View the `CURL` versions of the examples to see the proper endpoint for each query type.
+Different query types in this section should be issued to different API endpoints. View the `curl` versions of the examples to see the proper endpoint for each query type.
 
 ## Crawling the Graph {#crawling-the-graph}
 
@@ -12,7 +12,7 @@ For a forward traversal example, note our predicate `chat/person` which is of ty
 
 In order to also include the person details, we add to our select cause with a sub-query within our original query. This new query would look like:
 
-```flureeql
+```json
 {
   "select": [
     "*",
@@ -22,7 +22,7 @@ In order to also include the person details, we add to our select cause with a s
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -69,7 +69,7 @@ In FlureeQl, this syntax is declarative and looks like the shape of the data you
 
 As mentioned, these relationships can also be traversed in reverse. If instead of listing the person for every chat, what if we wanted to find all chats for a  person? Instead of selecting from `chat`, lets select from `person` and follow the same `chat/person` predicate but in the reverse direction. This query looks like:
 
-```flureeql
+```json
 {
   "select": [
     "*",
@@ -79,7 +79,7 @@ As mentioned, these relationships can also be traversed in reverse. If instead o
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -123,7 +123,7 @@ This special syntax indicates the same relationship, but in reverse. You'll now 
 
 For fun, you can add another sub-query to follow the chat message back to the person. Even though in this case it is redundant, and circular, Fluree exists happily in this paradox:
 
-```flureeql
+```json
 {
   "select": [
     "*",
@@ -133,7 +133,7 @@ For fun, you can add another sub-query to follow the chat message back to the pe
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -203,7 +203,7 @@ Key | Description
 
 For example, you can issue the following query:
 
-```all
+```json
 {
     "select": ["handle", "fullName"], 
     "from": "person"
@@ -212,7 +212,7 @@ For example, you can issue the following query:
 
 However, if you want to return `fullName` as `name`, you can issue the following query:
 
-```all
+```json
 {
     "select": ["handle", {"fullName": [{"_as": "name"}]}], 
     "from": "person"
@@ -221,7 +221,7 @@ However, if you want to return `fullName` as `name`, you can issue the following
 
 If you have a `ref` predicate, you can include any relevant sub-select options directly in the array where you specified any predicates you wanted to include:
 
-```all
+```json
 {
     "select": ["handle", {"comment/_person": ["*", {"_as": "comment", "_limit": 1}]}], 
     "from": "person"
@@ -230,7 +230,7 @@ If you have a `ref` predicate, you can include any relevant sub-select options d
 
 You can also sort each comment by `comment/message`.
 
-```all
+```json
 {
     "select": ["handle", {"comment/_person": ["*", {"_as": "comment", "_orderBy": "comment/message", "_limit": 1}]}], 
     "from": "person"
@@ -249,7 +249,7 @@ Key | Description
 `recur` | Number of times (integer) to follow a relationship. See [Recursion](#recursion). Only for `ref` predicates.
 `as` | Alternate name for a predicate. Only for `ref` predicates.
 
-```all
+```graphql
 { graph {
   person {
     _id
@@ -271,14 +271,14 @@ Recur is a sub-select option, which uses recursion to follow `ref` predicates th
 
 Normally, if we want to query who a person follows, we would submit this query.
 
-```flureeql
+```json
 {
     "select":["handle", {"person/follows": ["handle"]}],
     "from":"person"
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -313,14 +313,14 @@ curl \
 
 However, if you want to keep following the `person/follows` relationship, we can specify the number of times we want to follow the given relationship in the following manner:
 
-```flureeql
+```json
 {
     "select":["handle", {"person/follows": ["handle", {"_recur": 10}]}],
     "from":"person"
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -359,7 +359,7 @@ FlureeQL allows you to submit multiple queries at once by using the multi-query 
 
 For example, this query selects all chats and people at once.
 
-```flureeql
+```json
 {
     "chatQuery": {
         "select": ["*"],
@@ -372,7 +372,7 @@ For example, this query selects all chats and people at once.
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -414,7 +414,7 @@ curl \
 
 Any errors will be returned in a header, called `X-Fdb-Errors`. For example, incorrectCollection is attempting to query a collection that does not exist.
 
-```all
+```json
 {
     "incorrectCollection": {
         "select": ["*"],
@@ -429,7 +429,7 @@ Any errors will be returned in a header, called `X-Fdb-Errors`. For example, inc
 
 In FlureeQL, the response will have a status of 207, and it will only return the response for `personQuery`.
 
-```flureeql
+```json
 {
     "personQuery": [
       {

--- a/website/docs/overview/query/analytical-query.md
+++ b/website/docs/overview/query/analytical-query.md
@@ -74,7 +74,7 @@ If using `groupBy`, aggregates are applied only to the values within that group.
 
 If select a mixture of aggregate and non-aggregate variables, the results of the aggregate are returned alongside every non-aggregate value. To see what this looks like, try issuing the below query against the basic schema.
 
-```all
+```json
 {
   "select": ["?nums", "(avg ?nums)"],
   "where": [["?person", "person/favNums", "?nums"]]
@@ -135,7 +135,7 @@ Wikidata | `$wd` | Wikidata
 
 For example, the three tuple `["?person", "person/handle", "?handle"]` is equivalent to `["$fdb", "?person", "person/handle", "?handle"]`, because the specified source is the current ledger. The four tuple, `["$fdbPT2H", "?person", "person/handle", "?handle"]` is matching the given tuple pattern to the subject-predicate-object triples active in the ledger as of two hours ago.
 
-```all
+```json
 {
   "select": "?nums",
   "where": [["?person", "rdf:type", "person"],
@@ -150,8 +150,9 @@ You can bind a variable to an aggregate value. As mentioned above, where-array i
 
 Valid functions are the same as the ones listed in [Valid Aggregate Functions](#valid-aggregate-functions). You can also use the aggregate modifier (`distinct`) explained in the valid aggregate section (you can use the `as` modifier, but this will simply by ignored). A function must be preceded with a `#`.
 
-```flureeql
-{"select": "?hash", 
+```json
+{
+ "select": "?hash", 
  "where": [
     ["?s", "_block/number", "?bNum"],
     ["?maxBlock",  "#(max ?bNum)"],
@@ -160,7 +161,7 @@ Valid functions are the same as the ones listed in [Valid Aggregate Functions](#
 ]}
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -190,8 +191,9 @@ WHERE {
 
 You can also simply specify values as the second item in the tuple. This binds the given variable to the value provided.
 
-```all
-{"select": "?person", 
+```json
+{
+ "select": "?person", 
  "where": [
     ["?handle",  "jdoe"],
      ["?person", "person/handle", "?handle"]
@@ -206,7 +208,7 @@ A `bind` map (or multiple maps), can be declared anywhere in the where clause. T
 
 The map is comprised of keys that correspond to variables, and values. For example, `{"bind": {"?handle": "dsanchez"}}`. You can bind multiple variables in the same map, as well, for example `{"bind": {"?handle": "dsanchez", "?person": 351843720888324}}`.
 
-```flureeql
+```json
 {
   "select": [ "?person", "?handle"],
   "where": [
@@ -220,7 +222,7 @@ The map is comprised of keys that correspond to variables, and values. For examp
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -252,7 +254,7 @@ WHERE {
 
 Like intermediate aggregate clauses, binds can use aggregate functions. See the [Valid Aggregate Functions](#valid-aggregate-functions) list above.
 
-```flureeql
+```json
 {"select": "?hash", 
  "where": [
     ["?s", "_block/number", "?bNum"],
@@ -262,7 +264,7 @@ Like intermediate aggregate clauses, binds can use aggregate functions. See the 
 ]}
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -296,7 +298,7 @@ An optional map is map where the key is `optional`, and the value is an array of
 
 For example:
 
-```all
+```json
 { "optional": [ 
     [ "?person", "person/fullName", "?name"], 
     ["?favNums", 1223],
@@ -311,7 +313,7 @@ Anything within an optional map is resolved and then left outer joined with prev
 
 A union map takes an two-item array as a value. The two items in this array is itself an array comprised of any number of where-items (for example, three-tuples, two-tuples, optional maps, and filter maps). The results of each array of where-items is then outer joined.
 
-```all
+```json
 {
   "select": [ "?x", "?y", "?b", "?c", "?cname", "?pname"],
   "where": [
@@ -363,7 +365,7 @@ strEnds | `(strEnds ?message \"Amy.\")` | Returns true if the string ends with t
 
 An example query:
 
-```flureeql
+```json
 {
     "select": ["?handle", "?num"],
     "where": [  ["?person", "person/handle", "?handle"], 
@@ -372,7 +374,7 @@ An example query:
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -406,7 +408,7 @@ In the prefix map, we can specify what ledger we want to query across, in this c
 
 Now we can use `ftest` as a source in any clause.
 
-```flureeql
+```json
 {
     "prefixes": {
       "ftest": "fluree/test"
@@ -417,7 +419,7 @@ Now we can use `ftest` as a source in any clause.
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -464,7 +466,7 @@ The `vars` key takes a map where the keys are variable names and the values are 
 
 For example, in the below query `?handle` will be replaced with `dsanchez` anywhere it appears in the query.
 
-```flureeql
+```json
 {
     "select": "?handle",
     "where": [  
@@ -475,7 +477,7 @@ For example, in the below query `?handle` will be replaced with `dsanchez` anywh
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/overview/query/basic-query.md
+++ b/website/docs/overview/query/basic-query.md
@@ -36,7 +36,7 @@ The value of the select key is always an array. For the purposes of this section
   
    An `*` indicates "select all predicates" using the default options. An `*` may be used in conjunction with other select-array items, especially when the user wants to specify particular options. There are examples of this latter in the list.  
   
-   ```all
+   ```json
     {
       "select": ["*"],
       "from": "chat"
@@ -145,7 +145,7 @@ The value of the select key is always an array. For the purposes of this section
 
     A map can BOTH crawl the graph and have sub-select options. For example, `{"comment/_person": ["*", {"_as": "comment", "_limit": 1}]}`
 
-    ```all
+    ```json
     {
         "select": ["handle", {"comment/_person": ["*", {"_as": "comment", "_limit": 1}]}], 
         "from": "person"
@@ -154,7 +154,7 @@ The value of the select key is always an array. For the purposes of this section
 
     Below is another example using `_recur`.
 
-    ```all
+    ```json
     {
         "select":["handle", {"person/follows": ["handle", {"_recur": 10}]}],
         "from":"person"
@@ -187,7 +187,7 @@ an array of subject ids and unique two-tuples | `[87960930223082, ["person/handl
 
 Any select-array can be combined with any type of `from` key.
 
-```all
+```json
 {
   "select": ["*", {"chat/_person": ["*", {"_as": "chperson"}]}],
   "from": [87960930223082, ["person/handle", "jdoe"]]
@@ -208,21 +208,21 @@ Note: You are able to filter string values with `>`, `>=`, `<`, `<=`, although w
 
 You can link multiple specifications with `AND`s or `OR`s, for example `chat/instant > 1517437000000 AND chat/instant < 1517438000000`. However, you cannot submit a where clause with both an `AND` and an `OR`.
 
-```all
+```json
 {
   "select": ["chat/message", "chat/instant"],
   "where": "chat/instant > 1517437000000"
 }
 ```
 
-```all
+```json
 {
   "select": ["chat/message", "chat/instant"],
   "where": "chat/person = 351843720888322 OR chat/instant > 1517437000000"
 }
 ```
 
-```all
+```json
 {
   "select": ["handle"],
   "where": "person/handle != \"jdoe\" AND person/_chat"
@@ -235,7 +235,7 @@ A basic query can optionally have a block key, which issues that query as of a g
 
 Using a block number:
 
-```flureeql
+```json
 {
   "select": ["*"],
   "from": "chat",
@@ -243,7 +243,7 @@ Using a block number:
 }
 ```
 
-```curl
+```bash
  curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -273,7 +273,7 @@ Using a block number:
 
 Using an ISO-8601 formatted wall clock time:
 
- ```flureeql
+ ```json
 {
   "select": ["*"],
   "from": "chat",
@@ -281,7 +281,7 @@ Using an ISO-8601 formatted wall clock time:
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -310,7 +310,7 @@ Not supported
 
 Using an ISO-8601 formatted duration (as of 5 minutes ago):
 
- ```flureeql
+ ```json
 {
   "select": ["*"],
   "from": "chat",
@@ -318,7 +318,7 @@ Using an ISO-8601 formatted duration (as of 5 minutes ago):
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -361,7 +361,7 @@ Key | Value | Description
 
 For example:
 
-```all
+```json
 { 
   "select": ["*"], 
   "from": "person", 

--- a/website/docs/overview/query/basic-query.md
+++ b/website/docs/overview/query/basic-query.md
@@ -49,7 +49,7 @@ The value of the select key is always an array. For the purposes of this section
 
     Predicates do not have to be namespaced. The collection can often (but not always be inferred). For example, if selecting from the `chat` collection or a specific chat subject, `instant` is inferred to be `chat/instant`. However, with Fluree's flexible schema a predicate in any collection can be attached to any subject.
 
-    ```all
+    ```json
     {
         "select": ["chat/message", "instant", "*"],
         "from": "chat"
@@ -62,7 +62,7 @@ The value of the select key is always an array. For the purposes of this section
 
     You'll notice that when you just include `chat/person` in the select-array, your results will only show you the subject id (unique identifer) for the person.
 
-    ```all
+    ```json
     {
         "_id": 369435906932739,
         "chat/message": "Hi! I'm a chat from Zach.",
@@ -77,7 +77,7 @@ The value of the select key is always an array. For the purposes of this section
 
     In addition, it does not matter whether the predicate you are crawling references one or many subjects - the syntax is identical (i.e. per our schema, a chat can only have one person `chat/person`, but a person can have multiple favorite movies `person/favMovies`. ).
 
-    ```all
+    ```json
     {
         "select": [    {"person": [ "*", "favMovies", "favNums"] }   ],
         "from": "chat"
@@ -86,7 +86,7 @@ The value of the select key is always an array. For the purposes of this section
 
     There is no limit to how many times we crawl the graph. For example, below we are crawling the graph to get the person associated with all the chats, as well as each person's favorite movies and favorite artists. We are also crawling the graph to get all the information about those favorite artists and favorite movies. This may look confusing at first, but a select-array is simply made up of any combination of the listed items with an unlimited amount of nesting.
 
-    ```all
+    ```json
     {
         "select": ["*", {"person": ["*", {"favMovies": ["*"] } , {"favArtists": ["*"] } ]}],
         "from": "chat"
@@ -101,7 +101,7 @@ The value of the select key is always an array. For the purposes of this section
 
     In the basic schema, a chat references a person via the `chat/person` predicate. We know that the following query works to select all `chat/person`s from the chat collection:
 
-    ```all
+    ```json
     {
       "select": ["chat/person"],
       "from": "chat"
@@ -110,7 +110,7 @@ The value of the select key is always an array. For the purposes of this section
 
     In order to get all chats that reference `person`s, we simply add an `_` after the `/`. So `chat/person` becomes `chat/_person`.
 
-    ```all
+    ```json
     {
       "select": ["chat/_person"],
       "from": "person"
@@ -125,7 +125,7 @@ The value of the select key is always an array. For the purposes of this section
 
     Reverse references can simply return the subject id (as in the query above) or you can crawl the graph with those preferences. Crawling the graph with a reverse reference has the same syntax and behaves the same way as crawling the graph with a regular reference.
 
-    ```all
+    ```json
     {
       "select": [{"chat/_person": ["*"]}],
       "from": "person"
@@ -136,7 +136,7 @@ The value of the select key is always an array. For the purposes of this section
 
     You can specify granular options that only apply to certain predicates. To do so, you need to create a map where the key is the predicate name and the value is an array with the sub-select option map inside. For example: `{"fullName": [{"_as": "name"}]}`. The sub-select option `as` renames `fullName` to `name` in the results. The full list of sub-select options is in the table below.
 
-    ```all
+    ```json
     {
         "select": ["handle", {"fullName": [{"_as": "name"}]}], 
         "from": "person"

--- a/website/docs/overview/query/block-query.md
+++ b/website/docs/overview/query/block-query.md
@@ -21,13 +21,13 @@ To query a single block, you specify the block number, an ISO-8601 formatted wal
 
 Using a block number:
 
-```flureeql
+```json
 {
   "block": 3
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -49,13 +49,13 @@ Not supported
 
 Using an ISO-8601 formatted wall-clock time:
 
-```flureeql
+```json
 {
   "block": "2017-11-14T20:59:36.097Z"
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -77,13 +77,13 @@ Not supported
 
 To query a range of block, specify a lower and upper limit (inclusive).
 
-```flureeql
+```json
 {
   "block": [3,5]
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -107,13 +107,13 @@ Not supported
 
 To query a range of block, starting with a lower limit, specify just the lower limit (inclusive).
 
-```flureeql
+```json
 {
   "block": [3]
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -d '{
@@ -136,14 +136,14 @@ Not supported
 
 In FlureeQL, you can pretty print the results of a block query by adding `"prettyPrint": true` to your query map. Any format of block query can be pretty printed.
 
-```flureeql
+```json
 {
   "block": [3],
   "prettyPrint": true
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -d '{

--- a/website/docs/overview/query/graphql.md
+++ b/website/docs/overview/query/graphql.md
@@ -14,7 +14,7 @@ Using GraphQL, you can only retrieve predicates from within the namespace that y
 
 Therefore, we can only retrieve predicates like `_id`, `message`, `person`, or `comments`, which are in the `chat` namespace.
 
-```all
+```graphql
 { graph {
   chat {
     _id
@@ -28,7 +28,7 @@ Fluree allows any reference predicate to point to any subject, regardless of col
 
 However, in order to retrieve references using GraphQL, the `restrictCollection` property of that predicate has to be set to a valid collection. This second example retrieves not only the `_id` and `message` for each chat, but the `_id` and `handle` predicates for the `person` associated with each `chat`.
 
-```all
+```graphql
 { graph {
   chat {
     _id
@@ -46,7 +46,7 @@ However, in order to retrieve references using GraphQL, the `restrictCollection`
 
 GraphQL does not usually support the use of wildcards ( `*`), so most GraphQL interfaces will show an error when you attempt to use a wildcard. However, if you submit, the following query, the expected results will be returned.
 
-```all
+```graphql
 # Note this may show an error in your GraphQL tool, but it will return the expected result. 
 
 { graph {
@@ -65,7 +65,7 @@ The syntax for doing so differs from FlureeQL to GraphQL. While FlureeQL uses th
 
 Using GraphQL:
 
-```all
+```graphql
 { graph {
   person {
     chat_Via_person {
@@ -80,7 +80,7 @@ Using GraphQL:
 
 Using FlureeQL
 
-```all
+```json
 {
   "select": [
     "*",
@@ -96,7 +96,7 @@ In order to query a specific block or range of blocks in GraphQL, you need to us
 
 Querying a single block
 
-```all
+```graphql
 query  {
   block(from: 3, to: 3)
 }
@@ -104,7 +104,7 @@ query  {
 
 Querying a range of blocks
 
-```all
+```graphql
 query  {
   block(from: 3, to: 5)
 }
@@ -112,7 +112,7 @@ query  {
 
 Querying a range of blocks starting from a lower limit
 
-```all
+```graphql
 query  {
   block(from: 3)
 }
@@ -122,7 +122,7 @@ query  {
 
 To query a specific subject id, you can use the `_id` option, as seen below.
 
-```all
+```graphql
 { graph {
   chat(_id: 369435906932737) {
     _id
@@ -137,7 +137,7 @@ To query a specific subject id, you can use the `_id` option, as seen below.
 
 To query a unique two-tuple, you can use the `ident` option, as seen below.
 
-```all
+```graphql
 # Note this may show an error in your GraphQL tool, but it will return the expected result. 
 
 { graph {
@@ -161,7 +161,7 @@ GraphQL queries allow you to sort any field at any level in the graph. In order 
 
 In the below example, we are sorting chat messages in alphabetical order.
 
-```all
+```graphql
 { graph {
   chat (sort: {attribute: "message", order: ASC}) {
     _id
@@ -174,7 +174,7 @@ In the below example, we are sorting chat messages in alphabetical order.
 
 The below query sorts every person alphabetically by their full name, and then sorts all of their comments by message.
 
-```all
+```graphql
 { graph {
    person (sort: {attribute: "fullName", order: ASC}) {
     fullName
@@ -189,7 +189,7 @@ The below query sorts every person alphabetically by their full name, and then s
 
 Query with sort. Get all chat messages sorted alphabetically by message.
 
-```all
+```graphql
 { graph {
   chat (sort: {attribute: "message", order: ASC}) {
     _id
@@ -202,7 +202,7 @@ Query with sort. Get all chat messages sorted alphabetically by message.
 
 Query with sort. Get all people, sorted alphabetically by full name, and get each person's chat messages sorted from oldest to newest.
 
-```all
+```graphql
 { graph {
    person (sort: {attribute: "fullName", order: ASC}) {
     fullName
@@ -223,7 +223,7 @@ As you can see in the below example, in order to add people, we store the JSON-f
 
 We also need to ensure that all `"` are escaped, like so `\"`. If you use `$` anywhere in your transaction, that also needs to be escaped. If using GraphQL for transactions, we recommend using `#` as the delimiting characters in tempids (i.e. `person#1` rather than `person$1`), as `#` does not need to be escaped.
 
-```all
+```graphql
 mutation addPeople ($myPeopleTx: JSON) {
   transact(tx: $myPeopleTx)
 }
@@ -253,7 +253,7 @@ Key | Description
 `recur` | Number of times (integer) to follow a relationship. Only for `ref` predicates.
 `as` | Alternate name for a predicate. Only for `ref` predicates.
 
-```all
+```graphql
 { graph {
   person {
     _id

--- a/website/docs/overview/query/history-query.md
+++ b/website/docs/overview/query/history-query.md
@@ -22,14 +22,14 @@ To view the history of a single subject, you can either specify a subject id or 
 
 For example, to query the history of an subject at block 4:
 
-```flureeql
+```json
 {
   "history": 369435906932737,
   "block": 4
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -52,14 +52,14 @@ Not supported
 
 To query the history at block 4 of an subject using a two-tuple of a unique predicate and value:
 
-```flureeql
+```json
 {
   "history": ["person/handle", "zsmith"],
   "block": 4
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -84,14 +84,14 @@ Not supported
 
 To query the history of an subject using an subject id from block 3 to 5:
 
-```flureeql
+```json
 {
   "history": 369435906932737,
   "block": [3, 5]
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -114,14 +114,14 @@ Not supported
 
 To query the history of an subject using an subject id from block 3 to the most recent block:
 
-```flureeql
+```json
 {
   "history": 369435906932737,
   "block": [3]
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -150,13 +150,13 @@ In the flake-format, either a predicate or a subject is required.
 
 For example, to query the history of updates to the `person/follows` predicate on the `["person/handle", "zsmith"]` subject, you could issue the following query:
 
-```flureeql
+```json
 {
   "history": [["person/handle", "zsmith"], "person/follows"]
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -180,13 +180,13 @@ Note that because we are not specifying any other parts of the flake-format, we 
 
 If, however, we were interested in looking at flakes that matched any subject with the predicate, `person/handle`, and the object, `jdoe`, we would issue:
 
-```flureeql
+```json
 {
   "history": [null, "person/handle", "jdoe"]
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -210,14 +210,14 @@ Not supported
 
 In FlureeQL, you can pretty print the results of a history query by adding `"prettyPrint": true` to your query map. Any format of history query can be pretty printed.
 
-```flureeql
+```json
 {
   "history": [null, "person/handle", "jdoe"],
   "prettyPrint": true
 }
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -d '{
@@ -240,7 +240,7 @@ Not supported
 
 The pretty printed results look as follows:
 
-```all
+```json
 {
   "4": {
     "asserted": [
@@ -258,7 +258,7 @@ The pretty printed results look as follows:
 
 To include auth information in the results of a history query, include the `showAuth` key. For example:
 
-```all
+```json
 {
   "history": [null, "_collection/name"],
   "showAuth": true
@@ -267,7 +267,7 @@ To include auth information in the results of a history query, include the `show
 
 This could return results like:
 
-```all
+```json
 [
   {
     "block": 2,
@@ -306,7 +306,7 @@ This could return results like:
 
 You are also able to filter history query results to only incldue results corresponding to a particular auth record or auth records.
 
-```all
+```json
 {
   "history": [ null, "_collection/name"],
   "showAuth": true,
@@ -316,7 +316,7 @@ You are also able to filter history query results to only incldue results corres
 
 This returns the following results:
 
-```all
+```json
 [
   {
     "block": 2,

--- a/website/docs/overview/query/sparql.md
+++ b/website/docs/overview/query/sparql.md
@@ -69,7 +69,7 @@ object | `jdoe` | We are looking for results where the subject can be anything, 
 
 We can combine this simple triple, `?person fd:person/handle "jdoe"` with additional triples, for example:
 
-```all
+```sparql
 SELECT ?person
 WHERE {
   ?person fd:person/handle "jdoe".
@@ -89,7 +89,7 @@ Both the first and the second triples use the `?person` variable, which means th
 
 If two triples contain the same subject, then we can shorten the triples by using a semicolon `;` after the first clause and omitting the subject in all subsequent triples that share a subject. Make sure that the final clause in the group is has a period `.` at the end.
 
-```all
+```sparql
 SELECT ?person ?fullName ?favNums
 WHERE {
   ?person fd:person/handle "jdoe";
@@ -100,7 +100,7 @@ WHERE {
 
 If two triples contain the same subject and the same predicate, then we can shorten the triples by using a comma `,` after the first clause and omitting both the subject and predicate in all subsequent clauses that share both a subject and a predicate. Spacing, tabs, and new-lines do not effect the result of the query. In the examples, we write both objects on the same line for readability. The below query won't return anything, because no person has two different handles.
 
-```all
+```sparql
 SELECT ?person
 WHERE {
   ?person fd:person/handle "jdoe", "zsmith".
@@ -109,7 +109,7 @@ WHERE {
 
 We can also combine semicolons `;` and commas `,`. In the below example, we moved `fd:person/handle "jdoe", "zsmith"` to the bottom of the group of clauses for readability- it does not change the results of the query.
 
-```all
+```sparql
 SELECT ?person ?fullName ?favNums
 WHERE {
   ?person fd:person/fullName ?fullName;
@@ -124,7 +124,7 @@ All the queries with the `?person fd:person/handle "jdoe", "zsmith"` triple will
 
 Within the WHERE clause, you may include OPTIONAL clauses. For example, the below query will return all horses, including horses that may or may not have a mother listed.
 
-```all
+```sparql
 SELECT DISTINCT ?horse ?horseLabel ?mother 
 {
  ?horse wdt:P31/wdt:P279* wd:Q726 .    
@@ -146,7 +146,7 @@ Prefix | Source
 
 Note that if you are including a prefix that is supported by Wikidata, but external to it, i.e. `rdfs`, then you need to add a PREFIX clause to the top of your query. For example:
 
-```all
+```sparql
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT ...
 WHERE {
@@ -177,7 +177,7 @@ If you are returning Wikidata labels from your SPARQL query, the labels will aut
 
 For example, adding this SERVICE clause will return all labels in Russian:
 
-```all
+```sparql
 SELECT DISTINCT...
 WHERE {
   ...

--- a/website/docs/overview/query/sql.md
+++ b/website/docs/overview/query/sql.md
@@ -24,7 +24,7 @@ Queries involving a single collection can use short form variables. For example,
 to find all the known values of the `person/firstName` and `person/lastName`
 predicates for all subjects within the person collection, we can use the query:
 
-```SQL
+```sql
 SELECT firstName, lastName FROM person
 ```
 
@@ -49,7 +49,7 @@ for a subject id (`_id` predicate) directly however, you must use the special
 For example, to list the subject id and name for every subject within the
 "person" collection, you'd issue the following query:
 
-```SQL
+```sql
 SELECT $, name FROM person
 ```
 
@@ -96,13 +96,13 @@ used.
 For example, the following SQL query finds the name and job title for all
 subjects in a database holding a job:
 
-```SQL
+```sql
 SELECT person.name, job.title FROM person JOIN job ON person.job = job.$
 ```
 
 That Fluree SQL query is equivalent to the following FlureeQL query:
 
-```JSON
+```json
 {
   "select": [ "?personName" "?jobTitle" ],
   "where": [

--- a/website/docs/overview/schema/collections.md
+++ b/website/docs/overview/schema/collections.md
@@ -20,7 +20,7 @@ Predicate | Type | Description
 
 Creating collections is done in the same way as creating any other type of subject in the ledger. In the below example, we create four new collections: person, chat, comment, and artist. We strongly discourage adding smart functions to your `_collection/spec` when you initially create a collection. If you would like a `_collection/spec`, visit the [functions](/docs/schema/functions) section to understand how to incorporate smart functions into your schema.
 
-```flureeql
+```json
 [{
  "_id": "_collection",
  "name": "person",
@@ -47,7 +47,7 @@ Creating collections is done in the same way as creating any other type of subje
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -98,7 +98,7 @@ Transactions not supported in SPARQL
 
 You can do this by adding a new predicate:
 
-```flureeql
+```json
 [{
     "_id": "_predicate",
     "name": "_collection/longDescription",
@@ -106,7 +106,7 @@ You can do this by adding a new predicate:
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -134,14 +134,14 @@ Transactions not supported in SPARQL
 
 After you add this predicate, you can update any existing collections to include a long description:
 
-```flureeql
+```json
 [{
     "_id": ["_collection/name", "person"],
     "longDescription": "I have a lot to say about this collection, so this is a longer description about the person collection"
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -168,7 +168,7 @@ Transactions not supported in SPARQL
 
 And you can create new collections with a `_collection/longDescription`:
 
-```flureeql
+```json
 [{
     "_id": "_collection",
     "name": "animal",
@@ -176,7 +176,7 @@ And you can create new collections with a `_collection/longDescription`:
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -208,14 +208,14 @@ Although you can change built-in collection predicates, we do not recommend doin
 
 One commonly-requested safe change, however, is to allow `_collection/name` to be upsertable. By default, `_collection/name` does not allow upsert, meaning if you try to create a new collection with the name of already existing collection, an error will be thrown. You can change this, however, by editing the predicate, `_collection/name`. To see all the existing predicates for the `_collection/name` predicate, you can issue the following query:
 
-```flureeql
+```json
 {
     "select": ["*"],
     "from": ["_predicate/name", "_collection/name"]
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -239,7 +239,7 @@ WHERE {
 
 The default features of `_collection` name are:
 
-```all
+```json
 {
   "_predicate/name": "_collection/name",
   "_predicate/doc": "Schema collection name",
@@ -251,14 +251,14 @@ The default features of `_collection` name are:
 
 As we can see, there is no `upsert` key in the predicate, so by default upsert is false. To change this, we can issue:
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "_collection/name"],
     "upsert": true
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/overview/schema/predicates.md
+++ b/website/docs/overview/schema/predicates.md
@@ -59,7 +59,7 @@ In order to create a predicate, you only need to specify what type of subject yo
 
 If you would like a `_predicate/spec` or `txSpec`, which limits that allowed values for a predicate, see the [function](/docs/schema/functions) section.
 
-```flureeql
+```json
 [{
   "_id":    "_predicate",
   "name":   "person/handle",
@@ -83,7 +83,7 @@ If you would like a `_predicate/spec` or `txSpec`, which limits that allowed val
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -131,7 +131,7 @@ Transactions not supported in SPARQL
 
 You can do this by adding a new predicate:
 
-```flureeql
+```json
 [{
     "_id": "_predicate",
     "name": "_predicate/longDescription",
@@ -139,7 +139,7 @@ You can do this by adding a new predicate:
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -167,14 +167,14 @@ Transactions not supported in SPARQL
 
 After you add this predicate, you can update any existing predicates to include a long description:
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "person/handle"],
     "longDescription": "I have a lot to say about this predicate, so this is a longer description about the person/handle predicate"
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -201,7 +201,7 @@ Transactions not supported in SPARQL
 
 And you can create new predicates with a `_predicate/longDescription`:
 
-```flureeql
+```json
 [{
     "_id": "_predicate",
     "name": "_user/age",
@@ -210,7 +210,7 @@ And you can create new predicates with a `_predicate/longDescription`:
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -243,14 +243,14 @@ Although you can change built-in collection predicates, we do not recommend doin
 
 One commonly-requested safe change, however, is to allow `_predicate/name` to be upsertable. By default, `_predicate/name` does not allow upsert, meaning if you try to create a new predicate with the name of already existing predicate, an error will be thrown. You can change this, however, by editing the predicate, `_predicate/name`. To see all the existing predicates for the `_predicate/name` predicate, you can issue the following query:
 
-```flureeql
+```json
 {
     "select": ["*"],
     "from": ["_predicate/name", "_predicate/name"]
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -274,7 +274,7 @@ WHERE {
 
 The default features of `_predicate/name` are:
 
-```all
+```json
 {
   "_predicate/name": "_predicate/name",
   "_predicate/doc": "Predicate name",
@@ -286,14 +286,14 @@ The default features of `_predicate/name` are:
 
 As we can see, there is no `upsert` key in the predicate, so by default upsert is false. To change this, we can issue:
 
-```flureeql
+```json
 [{
     "_id": ["_predicate/name", "_predicate/name"],
     "upsert": true
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -324,7 +324,7 @@ Now, we allow upsert for the `_predicate/name` predicate.
 
 To see all of the predicates in a collection, you can use an analytical query with a filter, like below. To see all the predicates from any given collection, just replace `_collection` with the name of any collection.
 
-```flureeql
+```json
 {
     "select": {"?predicate": ["*"]},
     "where": [
@@ -334,7 +334,7 @@ To see all of the predicates in a collection, you can use an analytical query wi
 }
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/overview/schema/settings.md
+++ b/website/docs/overview/schema/settings.md
@@ -31,7 +31,7 @@ By default, all ledgers use English as a language. We support:
 
 To see all supported languages, you can also query:
 
-```all
+```json
 {
     "select": {"?tag": ["*"]},
     "where": [["?tag", "_tag/id", "?id"]],
@@ -41,7 +41,7 @@ To see all supported languages, you can also query:
 
 To see the language your ledger is currently set to, you can issue the query:
 
-```all
+```json
 {
   "select": [ "language" ],
   "from": ["_setting/id", "root"]
@@ -50,7 +50,7 @@ To see the language your ledger is currently set to, you can issue the query:
 
 To change your language, simply set your language setting to the two-letter code for your desired language. For example, to set a ledger to Russian, you can issue the transaction:
 
-```all
+```json
 [{
     "_id": ["_setting/id", "root"],
     "language": "ru" 
@@ -69,7 +69,7 @@ If not set, a default value of 2mb (i.e., 2e6) is used for the maximum transacti
 
 To see the current value of txMax for your ledger, you can issue the query:
 
-```all
+```json
 {
   "select": [ "txMax" ],
   "from": ["_setting/id", "root"]
@@ -78,7 +78,7 @@ To see the current value of txMax for your ledger, you can issue the query:
 
 To change the value for txMax, you can issue a transaction to specify the size limit in bytes:
 
-```all
+```json
 [{
     "_id": ["_setting/id", "root"],
     "txMax": 2e6 

--- a/website/docs/overview/schema/smart_functions.md
+++ b/website/docs/overview/schema/smart_functions.md
@@ -87,7 +87,7 @@ name of that smart function in other smart functions.
 For example, you can add a function called, `addThree` that adds 3 to any number,
 `n`.
 
-```flureeql
+```json
 [{
     "_id": "_fn",
     "name": "addThree",
@@ -96,7 +96,7 @@ For example, you can add a function called, `addThree` that adds 3 to any number
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -127,7 +127,7 @@ Transactions not supported in SPARQL
 Once, `addThree` is in the ledger, you can create a new function called `addTen`,
 which uses `addThree`.
 
-```flureeql
+```json
 [{
     "_id": "_fn",
     "name": "addTen",
@@ -136,7 +136,7 @@ which uses `addThree`.
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/overview/start/anywhere.md
+++ b/website/docs/overview/start/anywhere.md
@@ -41,7 +41,7 @@ To run Fluree with all the default options, navigate to the directory where you 
 
 When Fluree is done starting up, your terminal will log (exact log message may be different based on version):
 
-```all
+```bash
 - Starting web server on port: 8090 with an open API. -
 -
 - http://localhost:8090 -

--- a/website/docs/overview/start/installation.md
+++ b/website/docs/overview/start/installation.md
@@ -46,7 +46,7 @@ To run Fluree with all the default options, navigate to the directory where you 
 
 When Fluree is done starting up, your terminal will log:
 
-```all
+```bash
 Starting web server on port: [PORT NUMBER]
 ```
 
@@ -137,7 +137,7 @@ Note: not all of these configuration options are currently being used. Some opti
 
 For example, if you want to set `fdb-api-port` and `fdb-mode` when starting up Fluree, you would run:
 
-```all
+```bash
 ./fluree_start.sh -Dfdb-mode=transactor -Dfdb-api-port=8081
 ```
 
@@ -247,27 +247,27 @@ You can run these like so:
 
 On a Mac machine, you can download Fluree using Homebrew by running:
 
-```all
+```bash
 brew tap fluree/flureedb
 ```
 
-```all
+```bash
 brew install flureedb
 ```
 
 To run Fluree after installing it, run:
 
-```all
+```bash
 fluree
 ```
 
 To uninstall, run:
 
-```all
+```bash
 brew uninstall flureedb
 ```
 
-```all
+```bash
 brew untap fluree/flureedb
 ```
 

--- a/website/docs/overview/start/installation.md
+++ b/website/docs/overview/start/installation.md
@@ -154,7 +154,7 @@ Property | Options | Description
 `fdb-json-bigdec-string` | `boolean` | BigDecimals are not currently handled out-of-the-box by JavaScript applications.  This setting determines whether or not to encode java.Math.BigDecimal values as strings for query results, etc.  The default is `true`.
 `logback.configurationFile` | `file path` | Path to a `logback.xml` file. If it is in the current file, you need to specify `./logback.xml`. A sample `logback.xml` file is below. You can set the level of logging that you want to see (`INFO`, `DEBUG`, `TRACE`), as well as how frequently you want the your logback file scanned for updates. For more information, you can visit [the logback manual](https://logback.qos.ch/manual/index.html).
 
-```all
+```xml
 <configuration scan="true" scanPeriod="10 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/website/docs/overview/transact/adding-data.md
+++ b/website/docs/overview/transact/adding-data.md
@@ -4,7 +4,7 @@ In order to add data, you must use a [temporary id](/docs/transact/basics#tempor
 
 The keys can contain the full predicate name including the namespace, i.e. `chat/message` or you can leave off the namespace if it is the same as the collection the subject is within. i.e. when the subject is within the `chat` collection, just `message` can be used which is translated to `chat/message` by Fluree.
 
-```flureeql
+```json
 [{
   "_id":      "person",
   "handle":   "oRamirez",
@@ -17,7 +17,7 @@ The keys can contain the full predicate name including the namespace, i.e. `chat
 }]
 ```
 
-```curl
+```bash
   curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -58,7 +58,7 @@ If you are updating or creating a new subject, for example a new chat and that c
 
 FlureeQL example:
 
-```all
+```json
 [{
   "_id":     "chat",
   "message": "This is my first comment ever! So smart.",
@@ -77,7 +77,7 @@ Alternatively, you can nest transactions by simply declaring the new person dire
 
 FlureeQL example:
 
-```all
+```json
 [{
   "_id":     "chat",
   "message": "I have something to say!",

--- a/website/docs/overview/transact/basics.md
+++ b/website/docs/overview/transact/basics.md
@@ -19,7 +19,7 @@ Every transaction item must have an _id predicate to refer to the subject we are
 
 FlureeQL example:
 
-```all
+```json
 [{
     "_id":    "_user",
     "username": "eWasswa"
@@ -30,7 +30,7 @@ However, if you would like to reference that tempid somewhere else in your trans
 
 FlureeQL example:
 
-```all
+```json
 [{
     "_id":    "_user$lEliasz",
     "username": "lEliasz",
@@ -52,7 +52,7 @@ FlureeQL example:
 
 When issuing a transaction, you can include your own metadata. For example, if you want to include a `_tx/note`, you can issue the below transaction to create the relevant predicate (field):
 
-```all
+```json
 [{
     "_id": "_predicate",
     "name": "_tx/note",
@@ -62,7 +62,7 @@ When issuing a transaction, you can include your own metadata. For example, if y
 
 And, then, whenever you issue a transaction, you are able to include a _tx/note.
 
-```all
+```json
 [{
     "_id": "_user",
     "username": "abc"

--- a/website/docs/overview/transact/deleting-data.md
+++ b/website/docs/overview/transact/deleting-data.md
@@ -4,14 +4,14 @@
 
 To delete/retract an entire subject, use the `_id` key along with only `"_action": "delete"`. This deletes (retracts) the subject all predicates. In addition, all of the references for that subject anywhere in the ledger are also retracted.
 
-```flureeql
+```json
 [{
   "_id":      ["person/handle", "zsmith"],
   "_action":  "delete"
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -42,14 +42,14 @@ To delete only specific predicate-objects within an subject, specify the key/val
 
 You can delete (retract) a single predicate by setting the value of `_id` to a two-tuple of the predicate and predicate value, and then setting the predicate to null. `"_action": "delete"` is inferred.
 
-```flureeql
+```json
 [{
   "_id":      ["person/handle", "jdoe"],
   "age":   null
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -80,7 +80,7 @@ To delete (retract) only a single object from a multi predicate, specify the pre
 
 For example, to delete just the number, 98, from   `["person/handle", "jdoe"]`'s favorite numbers, we would issue:
 
-```flureeql
+```json
 [{
   "_id":      ["person/handle", "jdoe"],
   "favNums":   [98],
@@ -88,7 +88,7 @@ For example, to delete just the number, 98, from   `["person/handle", "jdoe"]`'s
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -116,14 +116,14 @@ Transactions not supported in SPARQL
 
 To delete all of `["person/handle", "jdoe"]`'s favorite numbers, we would issue:
 
-```flureeql
+```json
 [{
   "_id":      ["person/handle", "jdoe"],
   "favNums":  null
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/overview/transact/updating-data.md
+++ b/website/docs/overview/transact/updating-data.md
@@ -8,14 +8,14 @@ When referencing an existing subject,  `"_action": "update"` is inferred. Note: 
 
 Update using a two-tuple with a unique predicate. i.e. `person/handle` and relevant object:  
 
-```flureeql
+```json
 [{
   "_id":      ["person/handle", "dsanchez"],
   "age": 71
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -42,14 +42,14 @@ Transactions not supported in SPARQL
 
 Update using subject id:
 
-```flureeql
+```json
 [{
   "_id":      351843720888324,
   "age": 71
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \
@@ -80,7 +80,7 @@ You can upsert data if you have a unique predicate marked, `"upsert": true`. In 
 
 We can make `person/handle` a upsertable predicate with the following
 
-```all
+```json
 [{
     "_id": ["_predicate/name", "person/handle"],
     "upsert": true
@@ -89,7 +89,7 @@ We can make `person/handle` a upsertable predicate with the following
 
 After issuing the above transaction, we can issue the below transaction, which will just update jdoe's age, rather than creating a new person.
 
-```flureeql
+```json
 [{
   "_id":      "person",
   "handle":   "jdoe",
@@ -97,7 +97,7 @@ After issuing the above transaction, we can issue the below transaction, which w
 }]
 ```
 
-```curl
+```bash
 curl \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $FLUREE_TOKEN" \

--- a/website/docs/reference/clojure.md
+++ b/website/docs/reference/clojure.md
@@ -25,19 +25,19 @@ Add to the artifact to your dependencies:
 
 Leiningen -
 
-```clj
+```clojure
 [com.fluree/db "1.0.0-rc22"]
 ```
 
 deps.edn -
 
-```clj
+```clojure
 com.fluree/db {:mvn/version "1.0.0-rc22"}
 ```
 
 Require the api and establish a connection to your Fluree server:
 
-```clj
+```clojure
 (require '[fluree.db.api :as fdb])
 
 (def conn (fdb/connect "http://localhost:8090"))
@@ -57,7 +57,7 @@ All data transacted into a ledger must conform to a schema. We'll transact a bas
 
 Create a collection, which you can think of as a type of entity, or a relational database table.
 
-```clj
+```clojure
 ;; creates book and author collections
 @(fdb/transact conn ledger [{:_id :_collection :_collection/name :book}
                             {:_id :_collection :_collection/name :author}])
@@ -68,7 +68,7 @@ Create a collection, which you can think of as a type of entity, or a relational
 
 Create some predicates for the collection, analogous to entity attributes or relational database columns.
 
-```clj
+```clojure
 @(fdb/transact conn ledger [{:_id :_predicate
                              :_predicate/name :author/name
                              :_predicate/doc "An author's complete name."
@@ -105,7 +105,7 @@ Create some predicates for the collection, analogous to entity attributes or rel
 
 Insert some subject data that conforms to the schema we've created. See the [Transact](/docs/1.0.0/transact) documentation for more details.
 
-```clj
+```clojure
 ;; adding data
 @(fdb/transact conn ledger [{:_id :book
                              :book/title "Watership Down"
@@ -154,7 +154,7 @@ The syntax for these queries is similar to datalog and eql. These don't support 
 
 The `query` function takes a `db` value to execute a query against, as well as a query map. See the docs for [Analytical queries](/docs/1.0.0/query/analytical-query) and [Basic queries](/docs/1.0.0/query/overview) for more details.
 
-```clj
+```clojure
 ;; store the current immutable database value. See API docs for getting a prior version of a db, applying permissions to a db, and other options.
 (def db (fdb/db conn ledger))
 
@@ -173,7 +173,7 @@ The `query` function takes a `db` value to execute a query against, as well as a
 
 [History queries](/docs/1.0.0/query/history-query) can show you the raw history of a subject. Use `:pretty-print` to get back maps of predicate names to object values instead of raw flake data.
 
-```clj
+```clojure
 ;; see the history of the "Cryptonomicon" book.
 @(fdb/history-query (fdb/db conn ledger) {:history ["book/title" "Cryptonomicon"] :pretty-print true})
 ```
@@ -182,7 +182,7 @@ The `query` function takes a `db` value to execute a query against, as well as a
 
 [Block queries](/docs/1.0.0/query/block-query) return all of the raw flake data stored in a block. Use `:pretty-print` to get back maps of predicate names to object values instead of raw flake data.
 
-```clj
+```clojure
 ;; see all the flakes from block 3
 @(fdb/block-query-async conn ledger {:block 3 :pretty-print true})
 ```
@@ -191,7 +191,7 @@ The `query` function takes a `db` value to execute a query against, as well as a
 
 In addition to the FlureeQL syntax used above, Fluree also supports queries in other query languages: [SQL](/docs/1.0.0/query/sql), [SPARQL](/docs/1.0.0/query/sparql), [GraphQL](/docs/1.0.0/query/graphql). These can be used from Clojure by supplying a database value and a query string, or, in the case of GraphQL, a query map.
 
-```clj
+```clojure
 @(fdb/sql (fdb/db conn ledger) "select * from book")
 
 @(fdb/sparql (fdb/db conn ledger) "SELECT ?title WHERE { ?book fd:book/title ?title; fd:book/tags \"sci-fi\".}")
@@ -204,7 +204,7 @@ In addition to the FlureeQL syntax used above, Fluree also supports queries in o
 
 All of the interactions with the Fluree ledger server are performed asynchronously, returning a promise. If you prefer to work with `core.async` channels instead of promises, there are `-async` variants of all the functions mentioned here that will return a `core.async` channel which will receive the result when the operation has finished.
 
-```clj
+```clojure
 (require '[clojure.core.async :as async])
 
 (async/<!! (fdb/query-async (fdb/db conn ledger) {:select ["*"] :from "book"}))

--- a/website/docs/reference/http/examples.md
+++ b/website/docs/reference/http/examples.md
@@ -11,7 +11,7 @@ A POST request with an empty object or a GET request to `/fdb/dbs` returns all t
 
 An example of an unsigned request to `/dbs`.
 
-```all
+```http
 Action: POST or GET
 Endpoint: http://localhost:8090/fdb/dbs
 Headers: None
@@ -26,7 +26,7 @@ If the network specified does not exist, it creates a new network. This request 
 
 These requests do not need to be signed.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/new-db
 Headers: None
@@ -39,7 +39,7 @@ This provides a status of the Fluree network as recorded by a particular (ledger
 
 To retrieve the status, simply send an empty POST request to the `/nw-state` endpoint.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/nw-state
 Headers: None
@@ -48,7 +48,7 @@ Body: None
 
 The result is a map of key/value pairs, for example:
 
-```all
+```http
 {:snapshot-term 11,
  :latest-index 19940,
  :snapshot-index 19800,
@@ -91,14 +91,14 @@ This endpoint exports an existing ledger into either `xml` or `ttl`.
 You can optionally specify a block (as an integer). If none provided, defaults to the most recent block.
 You can optionally specify a format (`xml` or `ttl`). If none provided, defaults to `ttl`.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/export
 Headers: None
 Body: {"format": "ttl"}
 ```
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/export
 Headers: None
@@ -111,7 +111,7 @@ This deletes a ledger. Deleting a ledger means that a user will no longer be abl
 
 Use the following request when Fluree server is running in open-api mode (i.e., fdb-open-api=true)
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/delete-db
 Headers: None
@@ -120,7 +120,7 @@ Body: {"db/id": "NETWORK/DBID"}
 
 When the Fluree server is running in closed-api mode (i.e., fdb-open-api=false), the request must be signed. The process to sign the delete-db request is the similar to signing queries and transactions; only the end-point is different. .
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/delete-db
 Headers {:content-type :application/json,
@@ -136,13 +136,13 @@ This endpoint attempts to dynamically add server to the network. Please note, th
 
 Let's say you have two servers running, `ABC` and `DEF`, in order to get a third server, `GHI` to join the network, you need to start up server `GHI` with the following properties. Note the properties can be set in a property file or environment variables as well:
 
-```all
+```http
 ./fluree_start.sh -Dfdb-join?=true -Dfdb-group-servers=ABC@localhost:9790,DEF@localhost:9791,GHI@localhost:9792 -Dfdb-group-this-server=GHI -Dfdb-group-log-directory=data/GHI/raft/ -Dfdb-storage-file-directory=data/GHI/fdb/ -Dfdb-api-port=8092
 ```
 
 Then, once `GHI` is running a request needs to be sent to either of the two servers already in the network, `ABC` or `DEF`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/add-server
 Headers: None
@@ -159,7 +159,7 @@ This endpoint attempts to dynamically remove a server from the network. Please n
 
 Let's say you have three servers running, `ABC`, `DEF`, and `GHI`. If you want to shut down any of the servers, you can issue a request to any of the servers to shut down a given server.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/remove-server
 Headers: None
@@ -176,7 +176,7 @@ All single queries in FlureeQL syntax that include a `select` key should be issu
 
 An example of an unsigned request to `/query` with the network, `dev` and the ledger `main`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/query
 Headers: None
@@ -185,7 +185,7 @@ Body: { "select": ["*"], "from": "_collection"}
 
 An example of a signed request to `/query`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/query
 Headers: {
@@ -203,7 +203,7 @@ If you are submitting multiple FlureeQL queries at once (using the [multi-query 
 
 An example of an unsigned request to `/multi-query`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/multi-query
 Headers: None
@@ -213,7 +213,7 @@ Body: { "query1": { "select": ["*"], "from": "_collection"},
 
 An example of a signed request to `/multi-query`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/multi-query
 Headers: {
@@ -230,7 +230,7 @@ To build the body of this query, create unique names for your queries, and set t
 
 For example, this query selects all chats and people at once.
 
-```all
+```json
 {
     "chatQuery": {
         "select": ["*"],
@@ -245,7 +245,7 @@ For example, this query selects all chats and people at once.
 
 Any errors will be returned in a header, called `X-Fdb-Errors`. For example, incorrectCollection is attempting to query a collection that does not exist.
 
-```all
+```json
 {
     "incorrectCollection": {
         "select": ["*"],
@@ -260,7 +260,7 @@ Any errors will be returned in a header, called `X-Fdb-Errors`. For example, inc
 
 The response will have a status of 207, and it will only return the response for `personQuery`.
 
-```all
+```json
 {
     "personQuery": [
       {
@@ -280,7 +280,7 @@ FlureeQL [block queries](/docs/query/block-query) should be submitted to the `/b
 
 An example of an unsigned request to `/block`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/block
 Headers: None
@@ -293,7 +293,7 @@ FlureeQL [history queries](/docs/query/history-query) should be submitted to the
 
 An example of an unsigned request to `/history`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/history
 Headers: None
@@ -311,7 +311,7 @@ If you do not have `fdb-open-api` set to true (it is true by default), then you 
 
 An example of an unsigned request to `/transact`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/transact
 Headers: None
@@ -325,7 +325,7 @@ By specifying a `Request-Timeout` header, you can set a transaction timeout. The
 
 An example of setting your own custom timeout is below. The value provided to `Request-Timeout` is in milliseconds.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/transact
 Headers: {"Request-Timeout": 10000 }
@@ -341,7 +341,7 @@ All queries and transactions in GraphQL syntax should be issued through the `/fd
 
 An example of an unsigned request to `/graphql`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/graphql
 Headers: None
@@ -363,7 +363,7 @@ All queries and transactions in GraphQL syntax should be issued through the `/fd
 
 An example of an unsigned request to `/graphql`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/graphql
 Headers: None
@@ -383,7 +383,7 @@ All queries in SPARQL syntax, regardless of type, should be issued through the `
 
 An example of an unsigned request to `/sparql`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/sparql
 Headers: None
@@ -406,7 +406,7 @@ queries](/guides/0.16.0/identity/signatures#signed-queries)).
 
 An example of an unsigned request to `/sql`:
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/sql
 Headers: None
@@ -427,7 +427,7 @@ To see examples of sending a request to the `/command` endpoint, see [signed tra
 
 Available in `0.11.7` or higher. Reindexes the specified ledger.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/reindex
 Headers: None
@@ -436,7 +436,7 @@ Body: None
 
 This request may take some time to return. It will return a map, such as the following:
 
-```all
+```json
 {
     "block": 13,
     "t": -27,
@@ -452,7 +452,7 @@ This request may take some time to return. It will return a map, such as the fol
 
 This is a beta feature. To read about how it works, visit [hiding flakes](/docs/ledger-setup/mutability#hiding-flakes).
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/hide
 Headers: None
@@ -466,7 +466,7 @@ Body: {
 
 Returns the list of flakes that would be added to a ledger if a given transaction is issued. The body of this request is simply the transaction. Note that this is a test endpoint. This does _NOT_ write the returned flakes to the ledger.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/gen-flakes
 Headers: None
@@ -489,7 +489,7 @@ The request expects a map with two key-value pairs:
 
 The `t` on the flakes provided has to be current with the latest ledger. For example, if you used `gen-flakes`, but then issued a transaction, you will need to use `gen-flakes` again to generate new valid flakes.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/query-with
 Headers: None
@@ -512,7 +512,7 @@ The request expects a map with the following key-value pairs:
 
 The `t` on the flakes provided has to be current with the latest ledger. For example, if you used `gen-flakes`, but then issued a transaction, you will need to use `gen-flakes` again to generate new valid flakes.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/test-transact-with
 Headers: None
@@ -525,7 +525,7 @@ Body: {
 
 A POST request to `/fdb/[NETWORK-NAME]/[DBID]/block-range-with-txn` returns block stats, as well as flakes and transactions for the specified block(s).
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/block-range-with-txn
 Headers: None
@@ -538,7 +538,7 @@ Body: {
 
 A GET request to `/fdb/health` returns whether the server is ready or not. You are not able to test this endpoint in the sidebar. These requests do not need to be signed.
 
-```all
+```http
 Action: GET
 Endpoint: http://localhost:8090/fdb/health
 ```
@@ -547,7 +547,7 @@ Endpoint: http://localhost:8090/fdb/health
 
 A POST request to `/fdb/[NETWORK-NAME]/[DBID]/database-stats` provides stats about the requested ledger.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/database-stats
 Headers: None
@@ -558,14 +558,14 @@ Body: None
 
 A GET request to `/fdb/storage/[NETWORK-NAME]/[DBNAME-OR-DBID]/[TYPE]` returns all key-value pairs of a certain type. You are not able to test this endpoint in the sidebar. These requests do not need to be signed.
 
-```all
+```http
 Action: GET
 Endpoint: http://localhost:8090/fdb/storage/[NETWORK-NAME]/[DBNAME-OR-DBID]/[TYPE]
 ```
 
 A GET request to `/fdb/storage/[NETWORK-NAME]/[DBNAME-OR-DBID]/[TYPE]/[KEY]` returns the value for the provided key.
 
-```all
+```http
 Action: GET
 Endpoint: http://localhost:8090/fdb/storage/[NETWORK-NAME]/[DBNAME-OR-DBID]/[TYPE]/[KEY]
 ```
@@ -595,7 +595,7 @@ If using a closed API, this request needs to contain a valid token in the header
 
 The below request will return a valid token for the user, which has permissions that correspond to the listed user's roles.
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/pw/generate
 Headers:
@@ -616,7 +616,7 @@ This endpoint returns a valid JWT token. You need to pass a NON-expired JWT toke
 | ------ | -------- | -------------------------------------------------- |
 | expire | false    | Expiration time in epoch ms from now. i.e. `1000`. |
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/pw/renew
 Headers: { Authorization: "Bearer TOKEN-HERE" }
@@ -634,7 +634,7 @@ See the [Password Management Guide](/guides/identity/password-management) for mo
 | auth     | false    | You must pass in your `_auth_id` . Either a user or auth must be provided.      |
 | expire   | false    | Requested time to expire in epoch milliseconds, i.e. `1000`.                    |
 
-```all
+```http
 Action: POST
 Endpoint: http://localhost:8090/fdb/dev/main/pw/login
 Headers: { Authorization: "Bearer TOKEN-HERE" }

--- a/website/docs/reference/javascript/examples.md
+++ b/website/docs/reference/javascript/examples.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 You can dowbload the latest version of the Fluree JavaScript library from npm:
 
-```all
+```bash
 npm install @fluree/flureedb
 ```
 
@@ -38,7 +38,7 @@ Returns a connection object.
 
 An example of the `connect` command:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 var myConn = flureedb.connect(flureeServerUrl);
 ```
@@ -47,7 +47,7 @@ var myConn = flureedb.connect(flureeServerUrl);
 
 An example of the `connect_p` command:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 flureedb.connect_p(flureeServerUrl)
 .then(conn => {
@@ -65,7 +65,7 @@ flureedb.connect_p(flureeServerUrl)
 
 An example of using `connect_p` with `keep-alive-fn` option:
 
-```all
+```javascript
 function flureeConnect(url, options){
     if (!url) {
         throw "Unable to connect to Fluree: Missing url. "
@@ -114,7 +114,7 @@ Returns a boolean, false when the connection is not currently open; otherwise, t
 
 ### JavaScript Example {#javascript-example-1}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 var myConn = flureedb.connect(flureeServerUrl);
 :
@@ -139,7 +139,7 @@ Returns a queryable ledger as an asynchronous channel.
 
 ### JavaScript Example {#javascript-example-2}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -165,7 +165,7 @@ Returns a JavaScript promise that will eventually deliver the schema map for a l
 
 ### JavaScript Example {#javascript-example-3}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -206,7 +206,7 @@ A JavaScript promise that eventually contains a transaction id. The transaction 
 
 ### JavaScript Example {#javascript-example-4}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/invoice";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -234,7 +234,7 @@ Returns a promise that eventually the results
 
 ### JavaScript Example {#javascript-example-5}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 var myConn = flureedb.connect(flureeServerUrl);
 
@@ -263,7 +263,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of a query with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -305,7 +305,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of a `multi_query`:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -346,7 +346,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of a `block_query`:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -383,7 +383,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of a `block_range`:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -417,7 +417,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of a `history_query`:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -476,7 +476,7 @@ A JavaScript promise that eventually contains the transaction id or an error.
 
 An example of `transact` using the default private-key for the ledger to sign the transaction:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -499,7 +499,7 @@ flureedb.close(myConn);
 
 An example of a `transact` providing the private-key and auth to be used for signing:
 
-```all
+```javascript
 import { getSinFromPublicKey } from '@fluree/crypto-utils';
 :
 :
@@ -553,7 +553,7 @@ A JavaScript promise that eventually returns the results from the monitor_tx com
 
 An example of `monitor_tx`:
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -587,7 +587,7 @@ Returns true if the listener is successfully added. Otherwise, an exception is r
 
 ### JavaScript Example {#javascript-example-13}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn;
@@ -637,7 +637,7 @@ Returns true if a callback function was associated with the key and removed. Oth
 
 ### JavaScript Example {#javascript-example-14}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 const myLedgerName = "test/chat";
 var myConn = flureedb.connect(flureeServerUrl);
@@ -667,7 +667,7 @@ Returns a list of listeners registered for the given connection object.
 
 ### JavaScript Example {#javascript-example-15}
 
-```all
+```javascript
 const flureeServerUrl = "http://localhost:8090";
 var myConn = flureedb.connect(flureeServerUrl);
 :

--- a/website/docs/reference/nodejs/examples.md
+++ b/website/docs/reference/nodejs/examples.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 You can download the latest version of the Fluree Node.js library from npm:
 
-```all
+```bash
 npm install @fluree/flureenjs
 ```
 
@@ -36,7 +36,7 @@ The associated account id.
 
 Examples of account_id function:
 
-```all
+```javascript
   const flureenjs = require('@fluree/flureenjs');
   const message = "FlureeDL rocks!";
 
@@ -74,7 +74,7 @@ Returns the original block data, with flakes broken out into additions and retra
 
 ### Code Example {#code-example-1}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 const ledger = "test/chat";
@@ -113,7 +113,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of an unsigned request to `block_query`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 
 const flureeServerUrl = "http://localhost:8090";
@@ -147,7 +147,7 @@ The ID of a collection or nil when the collection does not exist.
 
 ### Code Example {#code-example-3}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 let flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -183,7 +183,7 @@ The `spot` index for the requested collection is returned.
 
 ### Code Example {#code-example-4}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 let flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -226,7 +226,7 @@ Returns a connection object.
 
 An example of the `connect` function:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -234,7 +234,7 @@ var flureeDbConn = flureenjs.connect(flureeServerUrl);
 
 An example of the `connect_p` function:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 var flureeDbConn;
 var flureeIsAvailable = false;
@@ -252,7 +252,7 @@ flureenjs.connect_p(flureeServerUrl)
 
 An example of using `connect_p` with `keep-alive-fn` option:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 function flureeConnect(url, options){
     if (!url) {
@@ -297,7 +297,7 @@ Returns a boolean, false when the connection is not currently open; otherwise, t
 
 ### Code Example {#code-example-5}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -324,7 +324,7 @@ Returns true if a callback function was associated with the key and removed. Oth
 
 ### Code Example {#code-example-6}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 const ledger = "test/chat";
@@ -358,7 +358,7 @@ Returns a queryable (point-in-time) ledger as an asynchronous channel.
 
 Code example without an explicit wait. This works well when the ledger/database is not immediately needed.
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -372,7 +372,7 @@ flureenjs.close(flureeDbConn);
 
 Code example using a promise.
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 let flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -405,7 +405,7 @@ Returns a promise that eventually contains the results.
 
 ### Code Example {#code-example-8}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -436,7 +436,7 @@ A JavaScript promise that eventually contains the results of the query.
 
 An example of an unsigned query to `graphql`:
 
-```all
+```javascript
     const flureenjs = require('@fluree/flureenjs');
     const flureeServerUrl = "http://localhost:8090";
     const ledger = "test/chat";
@@ -475,7 +475,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of an unsigned request to `history_query`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -516,7 +516,7 @@ Returns a signed http request.
 
 ### Code Example {#code-example-11}
 
-```all
+```javascript
   const flureenjs = require('@fluree/flureenjs');
   const flureeUrl = "http://localhost:8090";
   const rqst = {
@@ -551,7 +551,7 @@ Returns a map with information about the requested ledger.
 
 ### Code Example {#code-example-12}
 
-```all
+```javascript
   const flureenjs = require('@fluree/flureenjs');
   const flureeServerUrl = "http://localhost:8090";
   const ledger = "test/chat";
@@ -586,7 +586,7 @@ Returns a list of ledgers serviced by the connected Fluree instance.
 
 ### Code Example {#code-example-13}
 
-```all
+```javascript
   const flureenjs = require('@fluree/flureenjs');
   const flureeServerUrl = "http://localhost:8090";
   const ledger = "test/chat";
@@ -623,7 +623,7 @@ Returns a map with information about the requested ledger.
 
 ### Code Example {#code-example-14}
 
-```all
+```javascript
   const flureenjs = require('@fluree/flureenjs');
   const flureeServerUrl = "http://localhost:8090";
   const ledger = "test/chat";
@@ -661,7 +661,7 @@ Returns true if the listener is successfully added. Otherwise, an exception is r
 
 ### Code Example {#code-example-15}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 const ledger = "test/chat";
@@ -695,7 +695,7 @@ Returns a list of listeners registered for the given connection object.
 
 ### Code Example {#code-example-16}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -729,7 +729,7 @@ A JavaScript promise that eventually returns the results from the monitor_tx fun
 
 An example of an unsigned request to `monitor_tx`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 const ledger = "test/chat";
@@ -765,7 +765,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of an unsigned request to `multi_query`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -815,7 +815,7 @@ A JavaScript promise that eventually contains a transaction id. The transaction 
 
 ### Code Example {#code-example-19}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -842,7 +842,7 @@ A map containing the `private` key, `public` key and account (or auth) `id`.
 
 ### Code Example {#code-example-20}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 let { private, public, id } = flureenjs.new_private_key();
 ```
@@ -867,7 +867,7 @@ Returns a promise that eventually contains the token or an exception
 
 ### Code Example {#code-example-21}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -909,7 +909,7 @@ Returns a promise that eventually contains the token or an exception
 
 ### Code Example {#code-example-22}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -947,7 +947,7 @@ The id of a predicate or nil when the predicate does not exist.
 
 ### Code Example {#code-example-23}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -983,7 +983,7 @@ The name of a predicate or nil when the predicate does not exist.
 
 ### Code Example {#code-example-24}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1019,7 +1019,7 @@ The derived public key, or an exception if the message was not signed correctly.
 
 ### Code Example {#code-example-25}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const message = "Fluree rocks!";
 let { private } = flureenjs.new_private_key();
@@ -1044,7 +1044,7 @@ The associated public key.
 
 ### Code Example {#code-example-26}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 let { private } = flureenjs.new_private_key();
 let public = flureenjs.public_key_from_private(private);
@@ -1070,7 +1070,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of an unsigned request to `query` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1110,7 +1110,7 @@ Returns a promise that eventually contains the token or an exception
 
 ### Code Example {#code-example-28}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1158,7 +1158,7 @@ Returns a two-tuple of [network ledger-id]
 
 ### Code Example {#code-example-29}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1189,7 +1189,7 @@ Returns an array of flakes satisfying the search criteria.
 
 An example of an unsigned request to `query` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1221,7 +1221,7 @@ A JavaScript promise that eventually contains the session object.
 
 ### Code Example {#code-example-31}
 
-```all
+```javascript
     const flureenjs = require('@fluree/flureenjs');
     const flureeServerUrl = "http://localhost:8090";
     const ledger = "test/chat";
@@ -1256,7 +1256,7 @@ A JavaScript promise that eventually contains the results.
 
 ### Code Example {#code-example-32}
 
-```all
+```javascript
     const flureenjs = require('@fluree/flureenjs');
     const flureeServerUrl = "http://localhost:8090";
     const network = "test";
@@ -1292,7 +1292,7 @@ Not applicable.
 
 ### Code Example {#code-example-33}
 
-```all
+```javascript
     flureenjs.set_logging({level: "info"});
 ```
 
@@ -1313,7 +1313,7 @@ A signed message.
 
 ### Code Example {#code-example-34}
 
-```all
+```javascript
   const flureenjs = require('@fluree/flureenjs');
   const message = "FlureeDL rocks!";
 
@@ -1341,7 +1341,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of an unsigned request to `sparql` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
     const flureenjs = require('@fluree/flureenjs');
     const flureeServerUrl = "http://localhost:8090";
     const ledger = "test/chat";
@@ -1384,7 +1384,7 @@ A JavaScript promise that eventually contains the results of the query or an err
 
 An example of an unsigned request to `query` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1420,7 +1420,7 @@ The id of a subject or nil when the subject identity does not exist.
 
 ### Code Example {#code-example-37}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1478,7 +1478,7 @@ A JavaScript promise that eventually contains the transaction id or an error.
 
 An example of an unsigned request to `transact`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 const ledger = "test/chat";
@@ -1499,7 +1499,7 @@ flureenjs.close(flureeDbConn);
 
 An example of a signed request to `transact`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 import { getSinFromPublicKey } from '@fluree/crypto-utils';
 :
@@ -1567,7 +1567,7 @@ A JavaScript promise that eventually contains the results, or an exception.
 
 ### Code Example {#code-example-39}
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const private = '...';
 const ledger = "test/chat";
@@ -1596,7 +1596,7 @@ that would be added to a ledger.
 
 Consider the transaction,
 
-```all
+```javascript
 [{
   "_id":      ["person/handle", "dsanchez"],
   "age": 71
@@ -1605,7 +1605,7 @@ Consider the transaction,
 
 The corresponding Node.js fetch code would be:
 
-```all
+```javascript
 fetch("http://localhost:8090/fdb/test/chat/gen-flakes", {
   "headers": {
     "accept": "*/*",
@@ -1621,7 +1621,7 @@ fetch("http://localhost:8090/fdb/test/chat/gen-flakes", {
 And the results will look something like the following. The contents of the `flakes`
 array is used for the following functions.
 
-```all
+```javascript
 {
   "fuel": 599,
   "res": [
@@ -1686,7 +1686,7 @@ A JavaScript promise that eventually contains the new database instance or an er
 
 An example of an unsigned request to `query` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1720,7 +1720,7 @@ Returns true or false.
 
 An example of an unsigned request to `query` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);
@@ -1759,7 +1759,7 @@ Returns promise that eventually contains the results or an exception.
 
 An example of an unsigned request to `query` with the network, `test` and the ledger `chat`:
 
-```all
+```javascript
 const flureenjs = require('@fluree/flureenjs');
 const flureeServerUrl = "http://localhost:8090";
 var flureeDbConn = flureenjs.connect(flureeServerUrl);

--- a/website/docs/reference/serviceworker/examples.md
+++ b/website/docs/reference/serviceworker/examples.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 You can dowbload the latest version of the FlureeWorker library from npm:
 
-```all
+```bash
 npm install @fluree/flureeworker
 ```
 
@@ -156,7 +156,7 @@ Message received from FlureeWorker after processing a `close` request.
 
 Examples of `close` results
 
-```all
+```http
 {status:  200
  message: "Connection closed."}
 
@@ -180,7 +180,7 @@ Message received from FlureeWoker after processing a `connect` request.
 
 Example of `connStatus` results
 
-```all
+```http
 {status:  200
  message: "Connection is ready."}
 
@@ -203,7 +203,7 @@ Message received from FlureeWorker after processing a `login` request.
 
 Example of `login` results
 
-```all
+```http
 {status:  200
  result: {username: "sam" token: "eyJhbGc..."}}
 
@@ -226,7 +226,7 @@ Triggered when FlureeWorker receives ledger updates from the Fluree network. The
 
 Example of `setState` results
 
-```all
+```http
 {status: "loaded",
  result:[{"_id":369435906932739,"buyer":{"_id":351843720888324,"name":"ABC Flurian Group"},"id":"113","cost":75000,"items":["db","mobile app","app server","db server"],"seller":{"_id":351843720888321,"name":"Fluree"}},{"_id":369435906932738,"buyer":{"_id":351843720888324,"name":"ABC Flurian Group"},"id":"112","cost":2500,"items":["db"],"seller":{"_id":351843720888321,"name":"Fluree"}},{"_id":369435906932737,"buyer":{"_id":351843720888323,"name":"Leh-x Flurian Services"},"id":"111","cost":5000,"items":["db","application","server","mobile app"],"seller":{"_id":351843720888321,"name":"Fluree"}}]}
 ```

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,4 +1,4 @@
-const lightCodeTheme = require('prism-react-renderer/themes/github');
+const lightCodeTheme = require('prism-react-renderer/themes/okaidia');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -129,7 +129,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
-      additionalLanguages: ['turtle', 'sparql', 'clojure', 'http']
+      additionalLanguages: ['turtle', 'sparql', 'clojure', 'http', 'xml-doc']
     },
   },
   presets: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -129,6 +129,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
+      additionalLanguages: ['turtle', 'sparql', 'clojure']
     },
   },
   presets: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -129,7 +129,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
-      additionalLanguages: ['turtle', 'sparql', 'clojure']
+      additionalLanguages: ['turtle', 'sparql', 'clojure', 'http']
     },
   },
   presets: [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19437,6 +19437,7 @@
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
         "mkdirp": "^1.0.4",
+        "postcss": "^8.2.4",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {


### PR DESCRIPTION
This PR is for the configuration of additional language support for prism.js (code block language highlighting). The additional languages added were `http`, `sparql`, `turtle`, and `clojure`. These additions live in the `docusaurus.config.js` file.  In the future we might want to add `curl`, but for now we are using `bash` as a substitute. If we do decide to use `curl` we will need to configure a language definition file per the directions found [here](https://docusaurus.io/docs/next/markdown-features/code-blocks#supported-languages), a reference to how prism.js configures their language definitions can be found [here](https://github.com/PrismJS/prism/tree/master/components). 

One important issue to note is that when adding a new language that is not prepackaged in `prism-react-renderer`, but supported in prism.js, you need to run `cat node_modules/prismjs/components/prism-LANGUAGE_HERE.js` then double check that the language does or does not extend another language, if it does then you must place both into the `additionalLanguages` array. 

Please reference this github [issue](https://github.com/facebook/docusaurus/issues/2564#issuecomment-906623985) for context 