### PR TITLE
Remove refs to chocolatey as installation option

### DIFF
--- a/src/content/1.0.0/docs/start/anywhere.md
+++ b/src/content/1.0.0/docs/start/anywhere.md
@@ -26,7 +26,7 @@ Download and unzip: [latest stable version of Fluree](https://s3.amazonaws.com/f
 
 Or, you can get the [latest version of Fluree](https://s3.amazonaws.com/fluree-releases-public/fluree-latest.zip). 
 
-You can also download the latest Fluree with [Homebrew](/tools/other/tools#fluree-through-homebrew), [Docker](/tools/other/tools#fluree-on-docker), and [Chocolatey](/tools/other/tools#fluree-with-chocolatey) (coming soon).
+You can also download the latest Fluree with [Homebrew](/tools/other/tools#fluree-through-homebrew) or [Docker](/tools/other/tools#fluree-on-docker).
 
 ### Launching and Exiting Fluree
 

--- a/src/content/1.0.0/docs/start/installation.md
+++ b/src/content/1.0.0/docs/start/installation.md
@@ -37,7 +37,7 @@ Fluree requires Java 11 or above. To verify that your version of Java, you can t
 To run Fluree with all the default options, navigate to the directory where you downloaded Fluree in the terminal then launch Fluree with the following command:
 
 > For Mac or Linux systems: `./fluree_start.sh`
-> For Windows systems, you have to download a Bash emulator, like [Git For Windows](https://gitforwindows.org/) to properly run Fluree. In your Bash emulator, you can run `./fluree_start.sh` to start Fluree. Alternatively on Windows, you will be able to [download Fluree with Chocolatey](#download-fluree-with-chocolatey).
+> For Windows systems, you have to download a Bash emulator, like [Git For Windows](https://gitforwindows.org/) to properly run Fluree. In your Bash emulator, you can run `./fluree_start.sh` to start Fluree.
 
 When Fluree is done starting up, your terminal will log:
 
@@ -268,10 +268,6 @@ brew uninstall flureedb
 ```all
 brew untap fluree/flureedb
 ```
-
-### Download Fluree with Chocolatey
-
-This feature is coming soon.
 
 ### Fluree Command Line Tool
 


### PR DESCRIPTION
We have a few places where we are saying that Chocolately support is coming soon, which it isn't. A current client will be installing in Windows servers soon, so I would prefer to not have this in the docs anymore before they start their installations. 