### PR TITLE
Adds reindex-fullText to docs

### DIFF
--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
@@ -445,6 +445,31 @@ This request may take some time to return. It will return a map, such as the fol
 }
 ```
 
+### /reindex-fulltext
+
+Available in `0.11.7` or higher. Reindexes the specified ledger.
+
+```all
+Action: POST
+Endpoint: http://localhost:8090/fdb/dev/main/reindex-fulltext
+Headers: None
+Body: None
+```
+
+This request may take some time to return. It will return a map, such as the following:
+
+```all
+{
+    "block": 13,
+    "t": -27,
+    "stats": {
+        "flakes": 899990,
+        "size": 41435614,
+        "indexed": 13
+    }
+}
+```
+
 ### /hide
 
 This is a beta feature. To read about how it works, visit [hiding flakes](/docs/ledger-setup/mutability#hiding-flakes).

--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-overview.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-overview.md
@@ -26,6 +26,7 @@ SPARQL | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/sparql` | Queries in SPARQL synta
 SQL | `/fdb/[NETWORK-NAME]/[DBNAME-OR-DBID]/sql` | Queries in SQL syntax, as a string
 Command | `/fdb/[NETWORK-NAME]/[DBID]/command` | Commands, such as transactions, with a signature in the body. See [signing transactions](/guides/identity/signatures#signed-transactions).
 Reindex | `/fdb/[NETWORK-NAME]/[DBID]/reindex` | Reindexes the specified ledger.
+Reindex-fulltext | `/fdb/[NETWORK-NAME]/[DBID]/reindex` | Reindexes the fullText index on the specified ledger
 Hide | `/fdb/[NETWORK-NAME]/[DBID]/hide` | Hides flakes that match the given pattern.
 
 ### Test endpoints


### PR DESCRIPTION
Adds reference for /reindex-fulltext to the downloaded-api overview and examples page in current docs

Fixes: https://fluree.atlassian.net/browse/DR-371