### PR TITLE
remove all instances of database-stats

### DIFF
--- a/src/content/0.13.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/0.13.0/api/downloaded-endpoints/downloaded-examples.md
@@ -416,13 +416,13 @@ Action: GET
 Endpoint: http://localhost:8080/fdb/health
 ```
 
-### /database-stats
+### /ledger-stats
 
-A POST request to `/fdb/[NETWORK-NAME]/[DBID]/database-stats` provides stats about the requested ledger.
+A POST request to `/fdb/[NETWORK-NAME]/[DBID]/ledger-stats` provides stats about the requested ledger.
 
 ```all
 Action: POST
-Endpoint: http://localhost:8080/fdb/dev/main/database-stats
+Endpoint: http://localhost:8080/fdb/dev/main/ledger-stats
 Headers: None
 Body: None
 ```

--- a/src/content/0.15.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/0.15.0/api/downloaded-endpoints/downloaded-examples.md
@@ -524,13 +524,13 @@ Action: GET
 Endpoint: http://localhost:8080/fdb/health
 ```
 
-### /database-stats
+### /ledger-stats
 
-A POST request to `/fdb/[NETWORK-NAME]/[DBID]/database-stats` provides stats about the requested ledger.
+A POST request to `/fdb/[NETWORK-NAME]/[DBID]/ledger-stats` provides stats about the requested ledger.
 
 ```all
 Action: POST
-Endpoint: http://localhost:8080/fdb/dev/main/database-stats
+Endpoint: http://localhost:8080/fdb/dev/main/ledger-stats
 Headers: None
 Body: None
 ```

--- a/src/content/0.17.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/0.17.0/api/downloaded-endpoints/downloaded-examples.md
@@ -575,13 +575,13 @@ Action: GET
 Endpoint: http://localhost:8080/fdb/health
 ```
 
-### /database-stats
+### /ledger-stats
 
-A POST request to `/fdb/[NETWORK-NAME]/[DBID]/database-stats` provides stats about the requested ledger.
+A POST request to `/fdb/[NETWORK-NAME]/[DBID]/ledger-stats` provides stats about the requested ledger.
 
 ```all
 Action: POST
-Endpoint: http://localhost:8080/fdb/dev/main/database-stats
+Endpoint: http://localhost:8080/fdb/dev/main/ledger-stats
 Headers: None
 Body: None
 ```

--- a/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
+++ b/src/content/1.0.0/api/downloaded-endpoints/downloaded-examples.md
@@ -565,13 +565,13 @@ Action: GET
 Endpoint: http://localhost:8090/fdb/health
 ```
 
-### /database-stats
+### /ledger-stats
 
-A POST request to `/fdb/[NETWORK-NAME]/[DBID]/database-stats` provides stats about the requested ledger.
+A POST request to `/fdb/[NETWORK-NAME]/[DBID]/ledger-stats` provides stats about the requested ledger.
 
 ```all
 Action: POST
-Endpoint: http://localhost:8090/fdb/dev/main/database-stats
+Endpoint: http://localhost:8090/fdb/dev/main/ledger-stats
 Headers: None
 Body: None
 ```


### PR DESCRIPTION
Change all instances of `database-stats` to `ledger-stats`. These changes happened in this [commit](https://github.com/fluree/docs.flur.ee/commit/2caecb9972cbd9c55342c8937c6d548eb3ded900#diff-993d79bb20d48f059d2df08be5fd679d71e19a1620e819a649317bb3d7d49997), the inconsistency surfaced from this github [issue](https://github.com/fluree/developers-site/issues/5). 